### PR TITLE
Remove ember-data.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.1.2",
-    "ember-data": "1.0.0-beta.10",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },


### PR DESCRIPTION
It's not needed and was causing some warnings because it includes ember-inflector
