### PR TITLE
Use ember install:addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ## Usage
 
-* `npm install --save ember-moment`
-* `ember g ember-moment`
+* `ember install:addon ember-moment`
 
 ```hbs
 {{moment date}}


### PR DESCRIPTION
This PR proposes updating the install command documented in the README to use the new `ember install:addon` command, decreasing the chances of user error.

**Cons**: not compatible with Ember CLI < 1.5.0.

Not sure whether you'd prefer to leave the README as is or change it.