### PR TITLE
Version bump to 1.1.0, upgrading deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.1.0
+
+* [ENHANCEMENT] HTMLBars support (backwards compat. with Handlebars)
+
+* [ENHANCEMENT] Adding duration helper with examples in the dummy app
+
 ### 1.0.0
 
 * [BREAKING ENHANCEMENT] The full `moment` Handlebars helper signature is now

--- a/app/initializers/ember-moment.js
+++ b/app/initializers/ember-moment.js
@@ -4,8 +4,14 @@ import duration from 'ember-moment/helpers/duration';
 import Ember from 'ember';
 
 export var initialize = function(/* container, app */) {
-  var helper = (Ember.HTMLBars || Ember.Handlebars).helper;
-
+  var helper;
+  
+  if (Ember.HTMLBars) {
+      helper = Ember.HTMLBars._registerHelper;
+  } else {
+      helper = Ember.Handlebars.helper;
+  };
+ 
   helper('moment', moment);
   helper('ago', ago);
   helper('duration', duration);

--- a/bower.json
+++ b/bower.json
@@ -8,12 +8,12 @@
     "loader.js": "stefanpenner/loader.js#1.0.1",
     "ember-cli-moment-shim": "jasonmit/ember-cli-moment-shim#0.0.2",
     "ember-cli-shims": "stefanpenner/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
+    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.1",
     "ember-load-initializers": "stefanpenner/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.4",
+    "ember-qunit": "0.2.8",
+    "ember-qunit-notifications": "0.0.7",
     "moment": "~2.8.4",
-    "qunit": "~1.15.0"
+    "qunit": "~1.17.1"
   },
   "devDependencies": {
     "moment-timezone": "~0.2.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-moment",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Moment.js template helpers for ember",
   "directories": {
     "doc": "doc",
@@ -18,13 +18,13 @@
   "author": "Stefan Penner & Yapp Labs",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^1.0.0",
+    "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "ember-cli": "0.1.3",
-    "ember-cli-dependency-checker": "0.0.6",
+    "ember-cli": "0.1.15",
+    "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.1.2",
+    "ember-cli-qunit": "0.3.7",
     "express": "^4.8.5",
     "glob": "^4.0.5"
   },


### PR DESCRIPTION
I’m upgrading the bower/npm deps in line with ember-cli 0.1.15 produces.

Fixing HTMLBars register helper since Ember.HTMLBars.helper no longer exists