### PR TITLE
Export moment helper as a bound helper if it's htmlbars

### DIFF
--- a/addon/helpers/moment.js
+++ b/addon/helpers/moment.js
@@ -26,6 +26,7 @@ if (Ember.HTMLBars) {
 
     return momentjs.apply(this, args).format(output);
   };
+  moment = Ember.HTMLBars.makeBoundHelper(moment);
 } else {
   moment = function moment(value, maybeOutput, maybeInput) {
     var length = arguments.length;


### PR DESCRIPTION
We were getting SimpleStreams in the params in our app. This PR wraps the moment function in `Ember.HTMLBars.makeBoundHelper`.