### PR TITLE
Add moment-timezone to project

### DIFF
--- a/blueprints/ember-moment/index.js
+++ b/blueprints/ember-moment/index.js
@@ -8,7 +8,9 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('ember-cli-moment-shim');
-    return this.addBowerPackageToProject('moment-timezone');
+    return this.addBowerPackagesToProject([
+      { name: 'ember-cli-moment-shim' },
+      { name: 'moment-timezone' }
+    ]);
   }
 };

--- a/blueprints/ember-moment/index.js
+++ b/blueprints/ember-moment/index.js
@@ -9,5 +9,6 @@ module.exports = {
 
   afterInstall: function() {
     return this.addBowerPackageToProject('ember-cli-moment-shim');
+    return this.addBowerPackageToProject('moment-timezone');
   }
 };


### PR DESCRIPTION
It's not clear that you have to install moment-timezone.
Because moment-timezone is only included if `includeTimezone` is set we can just add the bower package without doing harm to anybody.