### PR TITLE
ability to add locale locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ module.exports = function(environment) {
   };
 ```
 
-### Include all locales
+### Include all locales into build
 
 ```js
 // config.environment.js
@@ -133,6 +133,8 @@ module.exports = function(environment) {
 
 ### Configure default runtime locale
 
+#### Globally
+
 ```js
 // app/routes/applicaton.js
 import moment from 'moment';
@@ -143,6 +145,17 @@ export default Ember.Route.extend({
     moment.locale('es');
   }
 });
+```
+
+#### Locally
+
+All helpers except a `locale` argument, which is a string.  This allows for overriding of the global locale.
+
+```hbs
+{{moment-format date locale='es'}}
+{{moment-duration date locale='es'}}
+{{moment-from-now date locale='es'}}
+{{moment-to-now date locale='es'}}
 ```
 
 Feature set of i18n support within moment can be found here:  http://momentjs.com/docs/#/i18n/

--- a/addon/helpers/moment-duration.js
+++ b/addon/helpers/moment-duration.js
@@ -1,13 +1,18 @@
 import moment from 'moment';
 
-function durationHelper(params) {
+function durationHelper(params, hash) {
   const length = params.length;
 
   if (length === 0 || length > 2) {
     throw new TypeError('Invalid Number of arguments, expected 1 or 2');
   }
 
-  return moment.duration.apply(this, params).humanize();
+  let time = moment.duration(...params);
+  if (hash.locale) {
+    time = time.locale(hash.locale);
+  }
+
+  return time.humanize();
 }
 
 export default durationHelper;

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-function momentHelper(params) {
+function momentHelper(params, hash) {
   const length = params.length;
   const args = [];
   let output;
@@ -20,7 +20,11 @@ function momentHelper(params) {
     output = params[1];
   }
 
-  return moment.apply(this, args).format(output);
+  let time = moment(...args);
+  if (hash.locale) {
+    time = time.locale(hash.locale);
+  }
+  return time.format(output);
 }
 
 export default momentHelper;

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -4,10 +4,8 @@ import moment from 'moment';
 const { later:runLater } = Ember.run;
 
 export var helperFactory = function(cb) {
-  let fromNow;
-
   if (Ember.Helper) {
-    fromNow = Ember.Helper.extend({
+    return Ember.Helper.extend({
       compute: function(params, hash) {
         if (typeof cb === 'function') {
           cb();
@@ -18,22 +16,28 @@ export var helperFactory = function(cb) {
         if (hash.interval) {
           runLater(this, this.recompute, parseInt(hash.interval, 10));
         }
-        return moment.apply(this, params).fromNow(hash.hideSuffix);
+        let time = moment(...params);
+        if (hash.locale) {
+          time = time.locale(hash.locale);
+        }
+        return time.fromNow(hash.hideSuffix);
       }
     });
   }
-  else {
-    fromNow = function(params, hash) {
-      if (typeof cb === 'function') {
-        cb();
-      }
-      if (params.length === 0) {
-        throw new TypeError('Invalid Number of arguments, expected at least 1');
-      }
-      return moment.apply(this, params).fromNow(hash.hideSuffix);
-    };
-  }
-  return fromNow;
+
+  return function momentFromNow(params, hash) {
+    if (typeof cb === 'function') {
+      cb();
+    }
+    if (params.length === 0) {
+      throw new TypeError('Invalid Number of arguments, expected at least 1');
+    }
+    let time = moment(...params);
+    if (hash.locale) {
+      time = time.locale(hash.locale);
+    }
+    return time.fromNow(hash.hideSuffix);
+  };
 };
 
 export default helperFactory();

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -4,10 +4,8 @@ import moment from 'moment';
 const { later:runLater } = Ember.run;
 
 export var helperFactory = function(cb) {
-  let toNow;
-
   if (Ember.Helper) {
-    toNow = Ember.Helper.extend({
+    return Ember.Helper.extend({
       compute: function(params, hash) {
         if (typeof cb === 'function') {
           cb();
@@ -18,22 +16,30 @@ export var helperFactory = function(cb) {
         if (hash.interval) {
           runLater(this, this.recompute, parseInt(hash.interval, 10));
         }
-        return moment.apply(this, params).toNow(hash.hidePrefix);
+
+        let time = moment(...params);
+        if (hash.locale) {
+          time = time.locale(hash.locale);
+        }
+        return time.toNow(hash.hidePrefix);
       }
     });
   }
-  else {
-    toNow = function(params, hash) {
-      if (typeof cb === 'function') {
-        cb();
-      }
-      if (params.length === 0) {
-        throw new TypeError('Invalid Number of arguments, expected at least 1');
-      }
-      return moment.apply(this, params).toNow(hash.hidePrefix);
-    };
-  }
-  return toNow;
+
+  return function momentToNow(params, hash) {
+    if (typeof cb === 'function') {
+      cb();
+    }
+    if (params.length === 0) {
+      throw new TypeError('Invalid Number of arguments, expected at least 1');
+    }
+
+    let time = moment(...params);
+    if (hash.locale) {
+      time = time.locale(hash.locale);
+    }
+    return time.toNow(hash.hidePrefix);
+  };
 };
 
 export default helperFactory();

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-moment",
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "1.13.6",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",

--- a/tests/unit/helpers/moment-duration-test.js
+++ b/tests/unit/helpers/moment-duration-test.js
@@ -1,10 +1,15 @@
+import Ember from 'ember';
+import { moduleFor, test } from 'ember-qunit';
 import moment from 'moment';
 import durationHelper from 'ember-moment/helpers/moment-duration';
 import callHelper from '../../helpers/call-helper';
+import hbs from 'htmlbars-inline-precompile';
+import { runAppend, runDestroy } from '../../helpers/run-append';
 
-module('DurationHelper', {
+moduleFor('helper:moment-duration', {
   setup() {
     moment.locale('en');
+    this.container.register('view:basic', Ember.View);
   }
 });
 
@@ -40,4 +45,18 @@ test('two args (value, units)', (assert) => {
   assert.expect(2);
   assert.equal(callHelper(durationHelper, [1, 'minutes', FAKE_HANDLEBARS_CONTEXT]), 'a minute');
   assert.equal(callHelper(durationHelper, [24, 'hours',  FAKE_HANDLEBARS_CONTEXT]), 'a day');
+});
+
+test('can inline a locale instead of using global locale', function(assert) {
+  assert.expect(1);
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-duration date locale='es'}}`,
+    context: {
+      date: 86400000
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'un día'); // note: that's not an `i` in día
+  runDestroy(view);
 });

--- a/tests/unit/helpers/moment-format-test.js
+++ b/tests/unit/helpers/moment-format-test.js
@@ -59,3 +59,17 @@ test('change date input and change is reflected by bound helper', function(asser
 
   runDestroy(view);
 });
+
+test('can inline a locale instead of using global locale', function(assert) {
+  assert.expect(1);
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-format date 'LLLL' locale='es'}}`,
+    context: {
+      date: date(date(0))
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'Miércoles, 31 de Diciembre de 1969 19:00');
+  runDestroy(view);
+});

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -54,3 +54,17 @@ test('change date input and change is reflected by bound helper', function(asser
 
   runDestroy(view);
 });
+
+test('can inline a locale instead of using global locale', function(assert) {
+  assert.expect(1);
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-from-now date locale='es'}}`,
+    context: {
+      date: new Date(new Date().valueOf() - (60*60*1000))
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'hace una hora');
+  runDestroy(view);
+});

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -53,3 +53,17 @@ test('change date input and change is reflected by bound helper', function(asser
 
   runDestroy(view);
 });
+
+test('can inline a locale instead of using global locale', function(assert) {
+  assert.expect(1);
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-to-now date locale='es'}}`,
+    context: {
+      date: new Date(new Date().valueOf() - (60*60*1000))
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'en una hora');
+  runDestroy(view);
+});


### PR DESCRIPTION
Can now pass locales as part of the helper, overriding the global option.

`{{moment-from-now date locale='fr'}}`