### PR TITLE
Fixing allow empty, deprecated helper regression, fixes ember-beta and ember-canary

### DIFF
--- a/addon/helpers/deprecated/ago.js
+++ b/addon/helpers/deprecated/ago.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
-import { helperFactory } from '../moment-from-now';
+import helperFactory from '../moment-from-now';
 
-export default helperFactory(function() {
-  Ember.deprecate('ember-moment: `ago` helper has been renamed to `moment-from-now`');
-});
+export default function(globalOutputFormat = 'LLLL', globalAllowEmpty = false) {
+  return function() {
+    Ember.deprecate('ember-moment: `ago` helper has been renamed to `moment-from-now`');
+    return helperFactory(globalOutputFormat, globalAllowEmpty)(...arguments);
+  };
+}

--- a/addon/helpers/deprecated/ago.js
+++ b/addon/helpers/deprecated/ago.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-import momentFromNowHelper from '../moment-from-now';
+import { helperFactory } from '../moment-from-now';
 
-export default function() {
+export default helperFactory(function() {
   Ember.deprecate('ember-moment: `ago` helper has been renamed to `moment-from-now`');
-  return momentFromNowHelper(...arguments);
-}
+});

--- a/addon/helpers/deprecated/moment.js
+++ b/addon/helpers/deprecated/moment.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import momentFormatHelper from '../moment-format';
 
-export default function() {
-  Ember.deprecate('ember-moment: `moment` helper has been renamed to `moment-format`');
-  return momentFormatHelper(...arguments);
+export default function(globalOutputFormat = 'LLLL', globalAllowEmpty = false) {
+  return function() {
+    Ember.deprecate('ember-moment: `moment` helper has been renamed to `moment-format`');
+    return momentFormatHelper(globalOutputFormat, globalAllowEmpty)(...arguments);
+  };
 }

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import computeFn from '../utils/compute-fn';
 
-export default function helperFactory(globalOutputFormat = 'LLLL') {
+export default function helperFactory(globalOutputFormat = 'LLLL', globalAllowEmpty = false) {
   return computeFn(function(params, hash) {
     const length = params.length;
 
@@ -29,5 +29,5 @@ export default function helperFactory(globalOutputFormat = 'LLLL') {
     }
 
     return time.format(output);
-  });
+  }, globalAllowEmpty);
 }

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
 import computeFn from '../utils/compute-fn';
 
-export default function helperFactory(globalOutputFormat = 'LLLL', allowEmpty = false) {
-  return computeFn(allowEmpty, function(params, hash) {
+export default function helperFactory(globalOutputFormat = 'LLLL') {
+  return computeFn(function(params, hash) {
     const length = params.length;
 
     if (length > 3) {

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -4,7 +4,7 @@ import computeFn from '../utils/compute-fn';
 
 const runBind = Ember.run.bind;
 
-export function helperFactory() {
+export default function helperFactory(globalAllowEmpty = false) {
   if (Ember.Helper) {
     return Ember.Helper.extend({
       compute: computeFn(function(params, hash) {
@@ -21,7 +21,7 @@ export function helperFactory() {
         }
 
         return time.fromNow(hash.hideSuffix);
-      }),
+      }, globalAllowEmpty),
       clearTimer() {
         clearTimeout(this.timer);
       },
@@ -40,7 +40,5 @@ export function helperFactory() {
     }
 
     return time.fromNow(hash.hideSuffix);
-  });
+  }, globalAllowEmpty);
 }
-
-export default helperFactory();

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -4,10 +4,10 @@ import computeFn from '../utils/compute-fn';
 
 const runBind = Ember.run.bind;
 
-export default function helperFactory(allowEmpty = false) {
+export function helperFactory() {
   if (Ember.Helper) {
     return Ember.Helper.extend({
-      compute: computeFn(allowEmpty, function(params, hash) {
+      compute: computeFn(function(params, hash) {
         this.clearTimer();
 
         if (hash.interval) {
@@ -32,7 +32,7 @@ export default function helperFactory(allowEmpty = false) {
     });
   }
 
-  return computeFn(allowEmpty, function(params, hash) {
+  return computeFn(function(params, hash) {
     let time = moment(...params);
 
     if (hash.locale) {
@@ -42,3 +42,5 @@ export default function helperFactory(allowEmpty = false) {
     return time.fromNow(hash.hideSuffix);
   });
 }
+
+export default helperFactory();

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -4,10 +4,10 @@ import computeFn from '../utils/compute-fn';
 
 const runBind = Ember.run.bind;
 
-export default function helperFactory(allowEmpty = false) {
+export function helperFactory() {
   if (Ember.Helper) {
     return Ember.Helper.extend({
-      compute: computeFn(allowEmpty, function(params, hash) {
+      compute: computeFn(function(params, hash) {
         this.clearTimer();
 
         if (hash.interval) {
@@ -32,7 +32,7 @@ export default function helperFactory(allowEmpty = false) {
     });
   }
 
-  return computeFn(allowEmpty, function(params, hash) {
+  return computeFn(function(params, hash) {
     let time = moment(...params);
 
     if (hash.locale) {
@@ -43,3 +43,4 @@ export default function helperFactory(allowEmpty = false) {
   });
 }
 
+export default helperFactory();

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -4,7 +4,7 @@ import computeFn from '../utils/compute-fn';
 
 const runBind = Ember.run.bind;
 
-export function helperFactory() {
+export default function helperFactory(globalAllowEmpty = false) {
   if (Ember.Helper) {
     return Ember.Helper.extend({
       compute: computeFn(function(params, hash) {
@@ -21,7 +21,7 @@ export function helperFactory() {
         }
 
         return time.toNow(hash.hidePrefix);
-      }),
+      }, globalAllowEmpty),
       clearTimer() {
         clearTimeout(this.timer);
       },
@@ -40,7 +40,5 @@ export function helperFactory() {
     }
 
     return time.toNow(hash.hidePrefix);
-  });
+  }, globalAllowEmpty);
 }
-
-export default helperFactory();

--- a/addon/utils/compute-fn.js
+++ b/addon/utils/compute-fn.js
@@ -1,19 +1,14 @@
 import Ember from 'ember';
 
-export default function(allowEmptyBoolean, cb) {
+export default function(cb) {
   return function(params, hash) {
     if (!params || params && params.length === 0) {
       throw new TypeError('ember-moment: Invalid Number of arguments, expected at least 1');
     }
 
     const datetime = params[0];
-    let allowEmpty = hash.allowEmpty || hash['allow-empty'];
-    if(allowEmpty === undefined || allowEmpty === null)
-    {
-      allowEmpty = allowEmptyBoolean;
-    }
 
-    if ([null, '', undefined].indexOf(datetime) > -1 && allowEmpty) {
+    if ([null, '', undefined].indexOf(datetime) > -1 && (hash.allowEmpty || hash['allow-empty'])) {
       Ember.Logger.warn('ember-moment: an empty value (null, undefined, or "") was passed to moment-format');
       return;
     }

--- a/addon/utils/compute-fn.js
+++ b/addon/utils/compute-fn.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default function(cb) {
+export default function(cb, globalAllowEmpty = false) {
   return function(params, hash) {
     if (!params || params && params.length === 0) {
       throw new TypeError('ember-moment: Invalid Number of arguments, expected at least 1');
@@ -8,7 +8,13 @@ export default function(cb) {
 
     const datetime = params[0];
 
-    if ([null, '', undefined].indexOf(datetime) > -1 && (hash.allowEmpty || hash['allow-empty'])) {
+    let allowEmpty = hash.allowEmpty || hash['allow-empty'];
+
+    if(allowEmpty === undefined || allowEmpty === null) {
+      allowEmpty = !!globalAllowEmpty;
+    }
+
+    if ([null, '', undefined].indexOf(datetime) > -1 && allowEmpty) {
       Ember.Logger.warn('ember-moment: an empty value (null, undefined, or "") was passed to moment-format');
       return;
     }

--- a/app/helpers/ago.js
+++ b/app/helpers/ago.js
@@ -1,8 +1,4 @@
-import Ember from 'ember';
 import deprecatedAgo from 'ember-moment/helpers/deprecated/ago';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
-import config from '../config/environment';
 
-export const computeFn = deprecatedAgo(Ember.get(config, 'moment.allowEmpty'));
-
-export default makeBoundHelper(computeFn);
+export default makeBoundHelper(deprecatedAgo);

--- a/app/helpers/ago.js
+++ b/app/helpers/ago.js
@@ -1,4 +1,12 @@
 import deprecatedAgo from 'ember-moment/helpers/deprecated/ago';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
+import config from '../config/environment';
 
-export default makeBoundHelper(deprecatedAgo);
+const { get } = Ember;
+
+export default makeBoundHelper(
+  deprecatedAgo(
+    get(config, 'moment.outputFormat'),
+    !!get(config, 'moment.allowEmpty')
+  )
+);

--- a/app/helpers/moment-format.js
+++ b/app/helpers/moment-format.js
@@ -3,6 +3,6 @@ import momentHelper from 'ember-moment/helpers/moment-format';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
 import config from '../config/environment';
 
-export const computeFn = momentHelper(Ember.get(config, 'moment.outputFormat'), Ember.get(config, 'moment.allowEmpty'));
+export const computeFn = momentHelper(Ember.get(config, 'moment.outputFormat'));
 
 export default makeBoundHelper(computeFn);

--- a/app/helpers/moment-format.js
+++ b/app/helpers/moment-format.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
-import momentHelper from 'ember-moment/helpers/moment-format';
+import momentFormatHelper from 'ember-moment/helpers/moment-format';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
 import config from '../config/environment';
 
-export const computeFn = momentHelper(Ember.get(config, 'moment.outputFormat'));
+const { get } = Ember;
 
-export default makeBoundHelper(computeFn);
+export const helper = momentFormatHelper(get(config, 'moment.outputFormat'), !!get(config, 'moment.allowEmpty'));
+export default makeBoundHelper(helper);

--- a/app/helpers/moment-from-now.js
+++ b/app/helpers/moment-from-now.js
@@ -1,4 +1,8 @@
-import momentFromNowHelper from 'ember-moment/helpers/moment-from-now';
+import helperFactory from 'ember-moment/helpers/moment-from-now';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
+import config from '../config/environment';
 
-export default makeBoundHelper(momentFromNowHelper);
+const { get } = Ember;
+
+export const helper = helperFactory(!!get(config, 'moment.allowEmpty'));
+export default makeBoundHelper(helper);

--- a/app/helpers/moment-from-now.js
+++ b/app/helpers/moment-from-now.js
@@ -1,8 +1,4 @@
-import Ember from 'ember';
 import momentFromNowHelper from 'ember-moment/helpers/moment-from-now';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
-import config from '../config/environment';
 
-export const computeFn = momentFromNowHelper(Ember.get(config, 'moment.allowEmpty'));
-
-export default makeBoundHelper(computeFn);
+export default makeBoundHelper(momentFromNowHelper);

--- a/app/helpers/moment-to-now.js
+++ b/app/helpers/moment-to-now.js
@@ -1,8 +1,4 @@
-import Ember from 'ember';
 import momentToNowHelper from 'ember-moment/helpers/moment-to-now';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
-import config from '../config/environment';
 
-export const computeFn = momentToNowHelper(Ember.get(config, 'moment.allowEmpty'));
-
-export default makeBoundHelper(computeFn);
+export default makeBoundHelper(momentToNowHelper);

--- a/app/helpers/moment-to-now.js
+++ b/app/helpers/moment-to-now.js
@@ -1,4 +1,8 @@
-import momentToNowHelper from 'ember-moment/helpers/moment-to-now';
+import helperFactory from 'ember-moment/helpers/moment-to-now';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
+import config from '../config/environment';
 
-export default makeBoundHelper(momentToNowHelper);
+const { get } = Ember;
+
+export const helper = helperFactory(!!get(config, 'moment.allowEmpty'));
+export default makeBoundHelper(helper);

--- a/app/helpers/moment.js
+++ b/app/helpers/moment.js
@@ -1,4 +1,12 @@
 import momentHelper from 'ember-moment/helpers/deprecated/moment';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
+import config from '../config/environment';
 
-export default makeBoundHelper(momentHelper);
+const { get } = Ember;
+
+export default makeBoundHelper(
+  momentHelper(
+    get(config, 'moment.outputFormat'),
+    !!get(config, 'moment.allowEmpty')
+  )
+);

--- a/app/helpers/moment.js
+++ b/app/helpers/moment.js
@@ -1,8 +1,4 @@
-import Ember from 'ember';
 import momentHelper from 'ember-moment/helpers/deprecated/moment';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
-import config from '../config/environment';
 
-export const computeFn = momentHelper(Ember.get(config, 'moment.allowEmpty'));
-
-export default makeBoundHelper(computeFn);
+export default makeBoundHelper(momentHelper);

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     var checker = new VersionChecker(this);
     var dep = checker.for('ember', 'bower');
 
-    if (dep.satisfies('>= 1.13.0 || >= 2')) {
+    if (dep.gt('1.13.0')) {
       tree = stew.rm(tree, 'initializers/legacy-register.js');
     }
 

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -5,7 +5,6 @@ import momentFromNow from 'ember-moment/computeds/from-now';
 
 export default Ember.Controller.extend({
   now: new Date(),
-  emptyDate: null,
   lastHour: new Date(new Date().valueOf() - (60*60*1000)),
   date: new Date(),
   numHours: 822,

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -4,6 +4,7 @@ import momentFormat from 'ember-moment/computeds/format';
 import momentFromNow from 'ember-moment/computeds/from-now';
 
 export default Ember.Controller.extend({
+  emptyDate: null,
   now: new Date(),
   lastHour: new Date(new Date().valueOf() - (60*60*1000)),
   date: new Date(),

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -38,42 +38,10 @@
 
 <hr>
 
-{{moment-format emptyDate allow-empty=true}}
-
-<code>
-  \{{moment-format emptyDate allow-empty=true}}
-</code>
-
-<hr>
-
-{{moment-to-now now}}
-
-<code>
-  \{{moment-to-now now}}
-</code>
-
-<hr>
-
-{{moment-to-now emptyDate allow-empty=true}}
-
-<code>
-  \{{moment-to-now emptyDate allow-empty=true}}
-</code>
-
-<hr>
-
 {{moment-from-now now}}
 
 <code>
   \{{moment-from-now now}}
-</code>
-
-<hr>
-
-{{moment-from-now emptyDate allow-empty=true}}
-
-<code>
-  \{{moment-from-now emptyDate allow-empty=true}}
 </code>
 
 <hr>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -46,22 +46,6 @@
 
 <hr>
 
-{{ago emptyDate allow-empty=true}}
-
-<code>
-  \{{ago emptyDate allow-empty=true}}
-</code>
-
-<hr>
-
-{{ago now}}
-
-<code>
-  \{{ago now}}
-</code>
-
-<hr>
-
 {{moment-to-now now}}
 
 <code>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,4 +1,4 @@
-{{moment-format now}}
+{{moment now}}
 
 <code>
   \{{moment-format now}}
@@ -29,6 +29,12 @@
 </code>
 
 <hr>
+
+{{moment-format emptyDate allow-empty=true}}
+{{moment-to-now emptyDate allow-empty=true}}
+{{moment emptyDate allow-empty=true}}
+{{ago emptyDate allow-empty=true}}
+{{moment-from-now emptyDate allow-empty=true}}
 
 {{moment-format now 'LL' 'LLLL'}}
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,7 +19,6 @@ module.exports = function(environment) {
     },
     moment: {
       outputFormat: 'LLLL',
-      allowEmpty: false,
       includeTimezone: 'all',
       includeLocales: ['es', 'fr-ca', 'fr']
     }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,6 +18,7 @@ module.exports = function(environment) {
       // when it is created
     },
     moment: {
+      allowEmpty: true,
       outputFormat: 'LLLL',
       includeTimezone: 'all',
       includeLocales: ['es', 'fr-ca', 'fr']

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -1,12 +1,8 @@
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
-import momentFromNow from 'ember-moment/helpers/moment-from-now';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
-import callHelper from '../../helpers/call-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
-
-const FAKE_HANDLEBARS_CONTEXT = {};
 
 moduleFor('helper:moment-from-now', {
   setup() {
@@ -16,20 +12,41 @@ moduleFor('helper:moment-from-now', {
   }
 });
 
-test('one arg (date)', (assert) => {
-  assert.expect(2);
+test('one arg (date)', function(assert) {
+  assert.expect(1);
+
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-  assert.equal(callHelper(momentFromNow, [threeDaysAgo, FAKE_HANDLEBARS_CONTEXT]), '3 days ago');
-  assert.equal(callHelper(momentFromNow, [moment(), FAKE_HANDLEBARS_CONTEXT]), 'a few seconds ago');
+
+  const context = Ember.Object.create({
+    date: threeDaysAgo
+  });
+
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-from-now date}}`,
+    context: context
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '3 days ago');
 });
 
-test('two args (date, inputFormat)', (assert) => {
-  assert.expect(2);
+test('two args (format, date)', function(assert) {
+  assert.expect(1);
+
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-  assert.equal(callHelper(momentFromNow, [threeDaysAgo, 'LLLL', FAKE_HANDLEBARS_CONTEXT]), '3 days ago');
-  assert.equal(callHelper(momentFromNow, [moment(), 'LLLL', FAKE_HANDLEBARS_CONTEXT]), 'a few seconds ago');
+
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-from-now date format}}`,
+    context: {
+      format: 'LLLL',
+      date: threeDaysAgo
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '3 days ago');
 });
 
 test('change date input and change is reflected by bound helper', function(assert) {

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -7,7 +7,6 @@ import callHelper from '../../helpers/call-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
 const FAKE_HANDLEBARS_CONTEXT = {};
-const subject = momentFromNow('LLLL');
 
 moduleFor('helper:moment-from-now', {
   setup() {
@@ -21,16 +20,16 @@ test('one arg (date)', (assert) => {
   assert.expect(2);
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-  assert.equal(callHelper(subject, [threeDaysAgo, FAKE_HANDLEBARS_CONTEXT]), '3 days ago');
-  assert.equal(callHelper(subject, [moment(), FAKE_HANDLEBARS_CONTEXT]), 'a few seconds ago');
+  assert.equal(callHelper(momentFromNow, [threeDaysAgo, FAKE_HANDLEBARS_CONTEXT]), '3 days ago');
+  assert.equal(callHelper(momentFromNow, [moment(), FAKE_HANDLEBARS_CONTEXT]), 'a few seconds ago');
 });
 
 test('two args (date, inputFormat)', (assert) => {
   assert.expect(2);
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-  assert.equal(callHelper(subject, [threeDaysAgo, 'LLLL', FAKE_HANDLEBARS_CONTEXT]), '3 days ago');
-  assert.equal(callHelper(subject, [moment(), 'LLLL', FAKE_HANDLEBARS_CONTEXT]), 'a few seconds ago');
+  assert.equal(callHelper(momentFromNow, [threeDaysAgo, 'LLLL', FAKE_HANDLEBARS_CONTEXT]), '3 days ago');
+  assert.equal(callHelper(momentFromNow, [moment(), 'LLLL', FAKE_HANDLEBARS_CONTEXT]), 'a few seconds ago');
 });
 
 test('change date input and change is reflected by bound helper', function(assert) {

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -7,7 +7,6 @@ import callHelper from '../../helpers/call-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
 const FAKE_HANDLEBARS_CONTEXT = {};
-const subject = momentToNow('LLLL');
 
 moduleFor('helper:moment-to-now', {
   setup() {
@@ -21,14 +20,14 @@ test('one arg (date)', (assert) => {
   assert.expect(1);
   const addThreeDays = new Date();
   addThreeDays.setDate(addThreeDays.getDate() - 3);
-  assert.equal(callHelper(subject, [addThreeDays, FAKE_HANDLEBARS_CONTEXT]), 'in 3 days');
+  assert.equal(callHelper(momentToNow, [addThreeDays, FAKE_HANDLEBARS_CONTEXT]), 'in 3 days');
 });
 
 test('two args (date, inputFormat)', (assert) => {
   assert.expect(1);
   const addThreeDays = new Date();
   addThreeDays.setDate(addThreeDays.getDate() - 3);
-  assert.equal(callHelper(subject, [addThreeDays, 'LLLL', FAKE_HANDLEBARS_CONTEXT]), 'in 3 days');
+  assert.equal(callHelper(momentToNow, [addThreeDays, 'LLLL', FAKE_HANDLEBARS_CONTEXT]), 'in 3 days');
 });
 
 test('change date input and change is reflected by bound helper', function(assert) {

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -1,12 +1,8 @@
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
-import momentToNow from 'ember-moment/helpers/moment-to-now';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
-import callHelper from '../../helpers/call-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
-
-const FAKE_HANDLEBARS_CONTEXT = {};
 
 moduleFor('helper:moment-to-now', {
   setup() {
@@ -16,18 +12,39 @@ moduleFor('helper:moment-to-now', {
   }
 });
 
-test('one arg (date)', (assert) => {
+test('one arg (date)', function(assert) {
   assert.expect(1);
   const addThreeDays = new Date();
   addThreeDays.setDate(addThreeDays.getDate() - 3);
-  assert.equal(callHelper(momentToNow, [addThreeDays, FAKE_HANDLEBARS_CONTEXT]), 'in 3 days');
+
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-to-now date}}`,
+    context: {
+      date: addThreeDays
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'in 3 days');
+  runDestroy(view);
 });
 
-test('two args (date, inputFormat)', (assert) => {
+test('two args (date, inputFormat)', function(assert) {
   assert.expect(1);
   const addThreeDays = new Date();
   addThreeDays.setDate(addThreeDays.getDate() - 3);
-  assert.equal(callHelper(momentToNow, [addThreeDays, 'LLLL', FAKE_HANDLEBARS_CONTEXT]), 'in 3 days');
+
+  const view = this.container.lookupFactory('view:basic').create({
+    template: hbs`{{moment-to-now date format}}`,
+    context: {
+      format: 'LLLL',
+      date: addThreeDays
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'in 3 days');
+  runDestroy(view);
 });
 
 test('change date input and change is reflected by bound helper', function(assert) {


### PR DESCRIPTION
#85 and #84 

Before I version, I plan to clean up the helpers a bit.  Separate < 1.13 helpers from >= 1.13 and include a build step to prune legacy vs modern.  This will clean up this change a bit more