### PR TITLE
Introduce `{{moment-relative}}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Master
+
+* Introduce `{{moment-relative}}` helper to deal with dates that may or may not
+  be in the future / past.
+
 ### 3.6.3-3.6.4
 
 * Ember version detection incorrectly reported

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 {{moment-format date}}
 {{moment-from-now date}}
 {{moment-to-now date}}
+{{moment-relative date}}
 {{moment-duration ms}}
 ```
 
@@ -32,6 +33,7 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 {{moment-format date outputFormat inputFormat}}
 {{moment-from-now date}}
 {{moment-to-now date}}
+{{moment-relative date}}
 {{moment-duration number units}}
 ```
 

--- a/addon/helpers/moment-relative.js
+++ b/addon/helpers/moment-relative.js
@@ -1,0 +1,19 @@
+import moment from 'moment';
+import computeFn from '../utils/compute-fn';
+
+export default function helperFactory(globalAllowEmpty = false) {
+  return computeFn(function(params, hash) {
+    let now = moment();
+    let time = moment(...params);
+
+    if (hash.locale) {
+      time = time.locale(hash.locale);
+    }
+
+    if (now.diff(time) < 0) { // time is in the future
+      return time.fromNow(hash.hideSuffix);
+    } else {
+      return time.toNow(hash.hidePrefix);
+    }
+  }, globalAllowEmpty);
+}

--- a/addon/modern/helpers/moment-relative.js
+++ b/addon/modern/helpers/moment-relative.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import config from '../config/environment';
+import Helper from 'ember-moment/helpers/moment-relative';
+
+export default Helper.extend({
+  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+});

--- a/app/helpers/moment-relative.js
+++ b/app/helpers/moment-relative.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import helperFactory from 'ember-moment/helpers/moment-relative';
+import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
+import config from '../config/environment';
+
+const helper = helperFactory(!!Ember.get(config, 'moment.allowEmpty'));
+
+export default makeBoundHelper(helper);

--- a/app/initializers/legacy-register.js
+++ b/app/initializers/legacy-register.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import momentToNowHelper from '../helpers/moment-to-now';
 import momentFromNowHelper from '../helpers/moment-from-now';
+import momentRelativeHelper from '../helpers/moment-relative';
 import momentFormatHelper from '../helpers/moment-format';
 import momentDurationHelper from '../helpers/moment-duration';
 import deprecatedMomentHelper from '../helpers/moment';
@@ -14,6 +15,7 @@ export function initialize(container) {
 
   Ember.HTMLBars._registerHelper('moment-to-now', momentToNowHelper);
   Ember.HTMLBars._registerHelper('moment-from-now', momentFromNowHelper);
+  Ember.HTMLBars._registerHelper('moment-relative', momentRelativeHelper);
   Ember.HTMLBars._registerHelper('moment-format', momentFormatHelper);
   Ember.HTMLBars._registerHelper('moment-duration', momentDurationHelper);
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -35,6 +35,7 @@
 {{moment emptyDate allow-empty=true}}
 {{ago emptyDate allow-empty=true}}
 {{moment-from-now emptyDate allow-empty=true}}
+{{moment-relative emptyDate allow-empty=true}}
 
 {{moment-format now 'LL' 'LLLL'}}
 
@@ -64,6 +65,12 @@
 
 <code>
   \{{moment-from-now usIndependenceDay}}
+</code>
+
+{{moment-relative usIndependenceDay}}
+
+<code>
+  \{{moment-relative usIndependenceDay}}
 </code>
 
 <hr>

--- a/tests/unit/helpers/moment-relative-test.js
+++ b/tests/unit/helpers/moment-relative-test.js
@@ -1,0 +1,173 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import moment from 'moment';
+import { moduleFor, test } from 'ember-qunit';
+import { runAppend, runDestroy } from '../../helpers/run-append';
+
+const { run } = Ember;
+
+let createView;
+
+moduleFor('helper:moment-relative', {
+  setup() {
+    const container = this.container;
+    const registry =  this.registry || this.container;
+    registry.register('view:basic', Ember.View);
+
+    createView = function (opts) {
+      return container.lookupFactory('view:basic').create(opts);
+    };
+
+    moment.locale('en');
+  }
+});
+
+test('one arg (date) in the future', function(assert) {
+  assert.expect(1);
+  const addThreeDays = new Date();
+  addThreeDays.setDate(addThreeDays.getDate() + 3);
+
+  const view = createView({
+    template: hbs`{{moment-relative date}}`,
+    context: {
+      date: addThreeDays
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'in 3 days');
+  runDestroy(view);
+});
+
+test('one arg (date) in the past', function(assert) {
+  assert.expect(1);
+  const subtractThreeDays = new Date();
+  subtractThreeDays.setDate(subtractThreeDays.getDate() - 3);
+
+  const view = createView({
+    template: hbs`{{moment-relative date}}`,
+    context: {
+      date: subtractThreeDays
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '3 days ago');
+  runDestroy(view);
+});
+
+test('two args (date, inputFormat) in the future', function(assert) {
+  assert.expect(1);
+  const addThreeDays = new Date();
+  addThreeDays.setDate(addThreeDays.getDate() + 3);
+
+  const view = createView({
+    template: hbs`{{moment-relative date format}}`,
+    context: {
+      format: 'LLLL',
+      date: addThreeDays
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'in 3 days');
+  runDestroy(view);
+});
+
+test('two args (date, inputFormat) in the past', function(assert) {
+  assert.expect(1);
+  const subtractThreeDays = new Date();
+  subtractThreeDays.setDate(subtractThreeDays.getDate() - 3);
+
+  const view = createView({
+    template: hbs`{{moment-relative date format}}`,
+    context: {
+      format: 'LLLL',
+      date: subtractThreeDays
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '3 days ago');
+  runDestroy(view);
+});
+
+test('change date input and change is reflected by bound helper', function(assert) {
+  assert.expect(2);
+  const context = Ember.Object.create({
+    date: new Date(new Date().valueOf() + (60*60*1000))
+  });
+
+  const view = createView({
+    template: hbs`{{moment-relative date}}`,
+    context: context
+  });
+
+  runAppend(view);
+
+  assert.equal(view.$().text(), 'in an hour');
+
+  run(function () {
+    context.set('date', new Date(new Date().valueOf() - (60*60*2000)));
+  });
+
+  assert.equal(view.$().text(), '2 hours ago');
+
+  runDestroy(view);
+});
+
+test('can inline a locale instead of using global locale', function(assert) {
+  assert.expect(1);
+  const view = createView({
+    template: hbs`{{moment-relative date locale='es'}}`,
+    context: {
+      date: new Date(new Date().valueOf() + (60*60*1000))
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'en una hora');
+  runDestroy(view);
+});
+
+test('can be called with null', function(assert) {
+  assert.expect(1);
+  const view = createView({
+    template: hbs`{{moment-relative date allow-empty=true}}`,
+    context: {
+      date: null
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '');
+  runDestroy(view);
+});
+
+test('can be called with null using global config option', function(assert) {
+  assert.expect(1);
+  const view = createView({
+    template: hbs`{{moment-relative date}}`,
+    context: {
+      date: null
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '');
+  runDestroy(view);
+});
+
+test('unable to called with null overriding global config option', function(assert) {
+  assert.expect(1);
+  const view = createView({
+    template: hbs`{{moment-relative date allow-empty=false}}`,
+    context: {
+      date: null
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'Invalid date');
+  runDestroy(view);
+});


### PR DESCRIPTION
Using `{{moment-from-now}}` assumes the date is in the future.

Using `{{moment-to-now}}` assumes the date is in the past.

If the date is unknown (i.e. potentially in the past, potentially in the
future), use `{{moment-relative}}`.