### PR TITLE
Destructure Hash params

### DIFF
--- a/addon/helpers/moment-duration.js
+++ b/addon/helpers/moment-duration.js
@@ -1,14 +1,14 @@
 import moment from 'moment';
 
-function durationHelper(params, hash) {
+function durationHelper(params, { locale }) {
   if (params.length > 2) {
     throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
   }
 
   let time = moment.duration(...params);
 
-  if (hash.locale) {
-    time = time.locale(hash.locale);
+  if (locale) {
+    time = time.locale(locale);
   }
 
   return time.humanize();

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 import computeFn from '../utils/compute-fn';
 
 export default function helperFactory(globalOutputFormat = 'LLLL', globalAllowEmpty = false) {
-  return computeFn(function(params, hash) {
+  return computeFn(function(params, { locale }) {
     const length = params.length;
 
     if (length > 3) {
@@ -24,8 +24,8 @@ export default function helperFactory(globalOutputFormat = 'LLLL', globalAllowEm
     }
 
     let time = moment(...args);
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
     return time.format(output);

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -2,13 +2,13 @@ import moment from 'moment';
 import computeFn from '../utils/compute-fn';
 
 export default function helperFactory(globalAllowEmpty = false) {
-  return computeFn(function(params, hash) {
+  return computeFn(function(params, { hideSuffix, locale }) {
     let time = moment(...params);
 
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
-    return time.fromNow(hash.hideSuffix);
+    return time.fromNow(hideSuffix);
   }, globalAllowEmpty);
 }

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -2,13 +2,13 @@ import moment from 'moment';
 import computeFn from '../utils/compute-fn';
 
 export default function helperFactory(globalAllowEmpty = false) {
-  return computeFn(function(params, hash) {
+  return computeFn(function(params, { hidePrefix, locale }) {
     let time = moment(...params);
 
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
-    return time.toNow(hash.hidePrefix);
+    return time.toNow(hidePrefix);
   }, globalAllowEmpty);
 }

--- a/addon/modern/helpers/moment-duration.js
+++ b/addon/modern/helpers/moment-duration.js
@@ -2,15 +2,15 @@ import Ember from 'ember';
 import moment from 'moment';
 
 export default Ember.Helper.extend({
-  compute: function(params, hash) {
+  compute: function(params, { locale }) {
     if (!params || params && params.length > 2) {
       throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
     }
 
     let time = moment.duration(...params);
 
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
     return time.humanize();

--- a/addon/modern/helpers/moment-format.js
+++ b/addon/modern/helpers/moment-format.js
@@ -6,7 +6,7 @@ export default Ember.Helper.extend({
   globalOutputFormat: 'LLLL',
   globalAllowEmpty: false,
 
-  compute: computeFn(function(params, hash) {
+  compute: computeFn(function(params, { locale }) {
     const length = params.length;
 
     if (length > 3) {
@@ -29,8 +29,8 @@ export default Ember.Helper.extend({
 
     let time = moment(...args);
 
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
     return time.format(output);

--- a/addon/modern/helpers/moment-from-now.js
+++ b/addon/modern/helpers/moment-from-now.js
@@ -7,20 +7,20 @@ const runBind = Ember.run.bind;
 export default Ember.Helper.extend({
   globalAllowEmpty: false,
 
-  compute: computeFn(function(params, hash) {
+  compute: computeFn(function(params, { hideSuffix, interval, locale }) {
     this.clearTimer();
 
-    if (hash.interval) {
-      this.timer = setTimeout(runBind(this, this.recompute), parseInt(hash.interval, 10));
+    if (interval) {
+      this.timer = setTimeout(runBind(this, this.recompute), parseInt(interval, 10));
     }
 
     let time = moment(...params);
 
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
-    return time.fromNow(hash.hideSuffix);
+    return time.fromNow(hideSuffix);
   }),
 
   clearTimer() {

--- a/addon/modern/helpers/moment-to-now.js
+++ b/addon/modern/helpers/moment-to-now.js
@@ -7,20 +7,20 @@ const runBind = Ember.run.bind;
 export default Ember.Helper.extend({
   globalAllowEmpty: false,
 
-  compute: computeFn(function(params, hash) {
+  compute: computeFn(function(params, { hidePrefix, interval, locale }) {
     this.clearTimer();
 
-    if (hash.interval) {
-      this.timer = setTimeout(runBind(this, this.recompute), parseInt(hash.interval, 10));
+    if (interval) {
+      this.timer = setTimeout(runBind(this, this.recompute), parseInt(interval, 10));
     }
 
     let time = moment(...params);
 
-    if (hash.locale) {
-      time = time.locale(hash.locale);
+    if (locale) {
+      time = time.locale(locale);
     }
 
-    return time.toNow(hash.hidePrefix);
+    return time.toNow(hidePrefix);
   }),
 
   clearTimer() {

--- a/app/initializers/legacy-register.js
+++ b/app/initializers/legacy-register.js
@@ -7,7 +7,7 @@ import deprecatedMomentHelper from '../helpers/moment';
 import deprecatedDurationHelper from '../helpers/duration';
 import deprecatedAgoHelper from '../helpers/ago';
 
-export function initialize(container) {
+export function initialize() {
   if (!Ember.HTMLBars) {
     throw new Error('HTMLBars is required with this version of ember-moment.');
   }


### PR DESCRIPTION
Destructuring optional hashes affords at least two benefits:

* self documenting - obvious which options are available
* reduce noise - `hash.option` vs `option`