### PR TITLE
Cleanup Test Suite

### DIFF
--- a/tests/helpers/hours-from-now.js
+++ b/tests/helpers/hours-from-now.js
@@ -1,0 +1,3 @@
+export default function(hours) {
+  return new Date(new Date().valueOf() + (60*60*1000*hours));
+}

--- a/tests/helpers/module-for-helper.js
+++ b/tests/helpers/module-for-helper.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import moment from 'moment';
+import { moduleFor } from 'ember-qunit';
+
+export default function(name, { needs } = {}) {
+  moduleFor(`helper:${name}`, {
+    needs,
+
+    setup() {
+      this.registry =  this.registry || this.container;
+      this.container = this.container || this.registry;
+
+      this.registry.register('view:basic', Ember.View);
+
+      this.createView = (opts) => {
+        return this.container.lookupFactory('view:basic').create(opts);
+      };
+
+      moment.locale('en');
+    }
+  });
+}

--- a/tests/unit/computeds/from-now-test.js
+++ b/tests/unit/computeds/from-now-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import hoursFromNow from '../../helpers/hours-from-now';
 import moment from 'moment';
 import momentFromNow from 'ember-moment/computeds/from-now';
 
@@ -10,7 +11,7 @@ module('agoComputed', {
 
 function createSubject(attrs) {
   return Ember.Object.extend(Ember.$.extend({
-    date: new Date(new Date().valueOf() - (60*60*1000)),
+    date: hoursFromNow(-1),
     ago: momentFromNow('date')
   }, attrs || {})).create();
 }
@@ -25,6 +26,6 @@ test('Formatter - get #2', (assert) => {
   assert.expect(2);
   const subject = createSubject();
   assert.equal(subject.get('ago'), 'an hour ago');
-  subject.set('date', new Date(new Date().valueOf() - (60*60*2000)));
+  subject.set('date', hoursFromNow(-2));
   assert.equal(subject.get('ago'), '2 hours ago');
 });

--- a/tests/unit/computeds/to-now-test.js
+++ b/tests/unit/computeds/to-now-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import hoursFromNow from '../../helpers/hours-from-now';
 import moment from 'moment';
 import momentToNow from 'ember-moment/computeds/to-now';
 
@@ -10,7 +11,7 @@ module('agoComputed', {
 
 function createSubject(attrs) {
   return Ember.Object.extend(Ember.$.extend({
-    date: new Date(new Date().valueOf() - (60*60*1000)),
+    date: hoursFromNow(-1),
     ago: momentToNow('date')
   }, attrs || {})).create();
 }
@@ -25,6 +26,6 @@ test('Formatter - get #2', (assert) => {
   assert.expect(2);
   const subject = createSubject();
   assert.equal(subject.get('ago'), 'in an hour');
-  subject.set('date', new Date(new Date().valueOf() - (60*60*2000)));
+  subject.set('date', hoursFromNow(-2));
   assert.equal(subject.get('ago'), 'in 2 hours');
 });

--- a/tests/unit/helpers/moment-duration-test.js
+++ b/tests/unit/helpers/moment-duration-test.js
@@ -1,30 +1,16 @@
-import Ember from 'ember';
-import { moduleFor, test } from 'ember-qunit';
-import moment from 'moment';
 import hbs from 'htmlbars-inline-precompile';
+import moduleForHelper from '../../helpers/module-for-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
+import { test } from 'ember-qunit';
 
-let createView;
-
-moduleFor('helper:moment-duration', {
+moduleForHelper('moment-duration', {
   needs: ['helper:duration'],
-  setup() {
-    const container = this.container;
-    const registry =  this.registry || this.container;
-    registry.register('view:basic', Ember.View);
-
-    createView = function (opts) {
-      return container.lookupFactory('view:basic').create(opts);
-    };
-
-    moment.locale('en');
-  }
 });
 
 test('one arg (ms)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date}}`,
     context: {
       date: 86400000
@@ -39,7 +25,7 @@ test('one arg (ms)', function(assert) {
 test('one arg (empty string)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date}}`,
     context: {
       date: ''
@@ -54,7 +40,7 @@ test('one arg (empty string)', function(assert) {
 test('one arg (object)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date}}`,
     context: {
       date: {
@@ -77,7 +63,7 @@ test('one arg (object)', function(assert) {
 test('one arg (string)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date}}`,
     context: {
       date: '23:59:59'
@@ -92,7 +78,7 @@ test('one arg (string)', function(assert) {
 test('two args (value, units) - minute', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date unit}}`,
     context: {
       unit: 'minutes',
@@ -108,7 +94,7 @@ test('two args (value, units) - minute', function(assert) {
 test('two args (value, units) - day', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date unit}}`,
     context: {
       unit: 'day',
@@ -124,7 +110,7 @@ test('two args (value, units) - day', function(assert) {
 test('(DEPRECATED) two args (value, units) - day', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{duration date unit}}`,
     context: {
       unit: 'day',
@@ -140,7 +126,7 @@ test('(DEPRECATED) two args (value, units) - day', function(assert) {
 test('two args (value, units) - empty value', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date unit}}`,
     context: {
       unit: 'minutes',
@@ -156,7 +142,7 @@ test('two args (value, units) - empty value', function(assert) {
 test('can inline a locale instead of using global locale', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-duration date locale='es'}}`,
     context: {
       date: 86400000

--- a/tests/unit/helpers/moment-format-test.js
+++ b/tests/unit/helpers/moment-format-test.js
@@ -1,32 +1,19 @@
 import Ember from 'ember';
-import moment from 'moment';
+import date from '../../helpers/date';
 import hbs from 'htmlbars-inline-precompile';
 import makeBoundHelper from 'ember-moment/utils/make-bound-helper';
-import { moduleFor, test } from 'ember-qunit';
-import date from '../../helpers/date';
+import moduleForHelper from '../../helpers/module-for-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
+import { test } from 'ember-qunit';
 
-let registry, createView;
-
-moduleFor('helper:moment-format', {
+moduleForHelper('moment-format', {
   needs: ['helper:moment'],
-  setup() {
-    const container = this.container;
-    registry =  this.registry || this.container;
-    registry.register('view:basic', Ember.View);
-
-    createView = function (opts) {
-      return container.lookupFactory('view:basic').create(opts);
-    };
-
-    moment.locale('en');
-  }
 });
 
 test('one arg (date)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format date}}`,
     context: {
       date: date(date(0))
@@ -41,7 +28,7 @@ test('one arg (date)', function(assert) {
 test('two args (date, inputFormat)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format date format}}`,
     context: {
       format: 'MMMM D, YYYY',
@@ -57,7 +44,7 @@ test('two args (date, inputFormat)', function(assert) {
 test('three args (date, outputFormat, inputFormat)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format date outputFormat inputFormat}}`,
     context: {
       inputFormat: 'M/D/YY',
@@ -74,7 +61,7 @@ test('three args (date, outputFormat, inputFormat)', function(assert) {
 test('(DEPRECATED) three args (date, outputFormat, inputFormat)', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment date outputFormat inputFormat}}`,
     context: {
       inputFormat: 'M/D/YY',
@@ -94,7 +81,7 @@ test('change date input and change is reflected by bound helper', function(asser
     date: date(0)
   });
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format date}}`,
     context: context
   });
@@ -114,7 +101,7 @@ test('change date input and change is reflected by bound helper', function(asser
 
 test('can inline a locale instead of using global locale', function(assert) {
   assert.expect(1);
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format date 'LLLL' locale='es'}}`,
     context: {
       date: date(date(0))
@@ -129,7 +116,7 @@ test('can inline a locale instead of using global locale', function(assert) {
 test('can be called with null when allow-empty is set to true', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format null allow-empty=true}}`,
     context: {
       date: null
@@ -144,11 +131,11 @@ test('can be called with null when allow-empty is set to true', function(assert)
 test('can be called using subexpression', function(assert) {
   assert.expect(1);
 
-  registry.register('helper:get-format', makeBoundHelper(function() {
+  this.registry.register('helper:get-format', makeBoundHelper(function() {
     return 'L';
   }));
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-format date (get-format 'global-format')}}`,
     context: {
       date: date(0)

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -1,24 +1,12 @@
 import Ember from 'ember';
+import { test } from 'ember-qunit';
+import moduleForHelper from '../../helpers/module-for-helper';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
-import { moduleFor, test } from 'ember-qunit';
+import hoursFromNow from '../../helpers/hours-from-now';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
-let createView;
-
-moduleFor('helper:moment-from-now', {
+moduleForHelper('moment-from-now', {
   needs: ['helper:ago'],
-  setup() {
-    const container = this.container;
-    const registry =  this.registry || this.container;
-    registry.register('view:basic', Ember.View);
-
-    createView = function (opts) {
-      return container.lookupFactory('view:basic').create(opts);
-    };
-
-    moment.locale('en');
-  }
 });
 
 test('one arg (date)', function(assert) {
@@ -31,7 +19,7 @@ test('one arg (date)', function(assert) {
     date: threeDaysAgo
   });
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-from-now date}}`,
     context: context
   });
@@ -46,7 +34,7 @@ test('two args (date, inputFormat)', function(assert) {
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-from-now date inputFormat}}`,
     context: {
       inputFormat: 'LLLL',
@@ -64,7 +52,7 @@ test('(DEPRECATED) ago two args (date, inputFormat)', function(assert) {
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{ago date inputFormat}}`,
     context: {
       inputFormat: 'LLLL',
@@ -79,10 +67,10 @@ test('(DEPRECATED) ago two args (date, inputFormat)', function(assert) {
 test('change date input and change is reflected by bound helper', function(assert) {
   assert.expect(2);
   const context = Ember.Object.create({
-    date: new Date(new Date().valueOf() - (60*60*1000))
+    date: hoursFromNow(-1),
   });
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-from-now date}}`,
     context: context
   });
@@ -92,7 +80,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.equal(view.$().text(), 'an hour ago');
 
   Ember.run(function () {
-    context.set('date', new Date(new Date().valueOf() - (60*60*2000)));
+    context.set('date', hoursFromNow(-2));
   });
 
   assert.equal(view.$().text(), '2 hours ago');
@@ -102,10 +90,10 @@ test('change date input and change is reflected by bound helper', function(asser
 
 test('can inline a locale instead of using global locale', function(assert) {
   assert.expect(1);
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-from-now date locale='es'}}`,
     context: {
-      date: new Date(new Date().valueOf() - (60*60*1000))
+      date: hoursFromNow(-1),
     }
   });
 
@@ -116,7 +104,7 @@ test('can inline a locale instead of using global locale', function(assert) {
 
 test('can be called with null', function(assert) {
   assert.expect(1);
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-from-now date allow-empty=true}}`,
     context: {
       date: null

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -1,31 +1,18 @@
 import Ember from 'ember';
+import { test } from 'ember-qunit';
+import moduleForHelper from '../../helpers/module-for-helper';
 import hbs from 'htmlbars-inline-precompile';
-import moment from 'moment';
-import { moduleFor, test } from 'ember-qunit';
+import hoursFromNow from '../../helpers/hours-from-now';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
-let createView;
-
-moduleFor('helper:moment-to-now', {
-  setup() {
-    const container = this.container;
-    const registry =  this.registry || this.container;
-    registry.register('view:basic', Ember.View);
-
-    createView = function (opts) {
-      return container.lookupFactory('view:basic').create(opts);
-    };
-
-    moment.locale('en');
-  }
-});
+moduleForHelper('moment-to-now');
 
 test('one arg (date)', function(assert) {
   assert.expect(1);
   const addThreeDays = new Date();
   addThreeDays.setDate(addThreeDays.getDate() - 3);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date}}`,
     context: {
       date: addThreeDays
@@ -42,7 +29,7 @@ test('two args (date, inputFormat)', function(assert) {
   const addThreeDays = new Date();
   addThreeDays.setDate(addThreeDays.getDate() - 3);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date format}}`,
     context: {
       format: 'LLLL',
@@ -59,10 +46,10 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.expect(2);
 
   const context = Ember.Object.create({
-    date: new Date(new Date().valueOf() - (60*60*1000))
+    date: hoursFromNow(-1),
   });
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date}}`,
     context: context
   });
@@ -72,7 +59,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.equal(view.$().text(), 'in an hour');
 
   Ember.run(function () {
-    context.set('date', new Date(new Date().valueOf() - (60*60*2000)));
+    context.set('date', hoursFromNow(-2));
   });
 
   assert.equal(view.$().text(), 'in 2 hours');
@@ -82,10 +69,10 @@ test('change date input and change is reflected by bound helper', function(asser
 
 test('can inline a locale instead of using global locale', function(assert) {
   assert.expect(1);
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date locale='es'}}`,
     context: {
-      date: new Date(new Date().valueOf() - (60*60*1000))
+      date: hoursFromNow(-1),
     }
   });
 
@@ -96,7 +83,7 @@ test('can inline a locale instead of using global locale', function(assert) {
 
 test('can be called with null', function(assert) {
   assert.expect(1);
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date allow-empty=true}}`,
     context: {
       date: null
@@ -111,7 +98,7 @@ test('can be called with null', function(assert) {
 test('can be called with null using global config option', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date}}`,
     context: {
       date: null
@@ -126,7 +113,7 @@ test('can be called with null using global config option', function(assert) {
 test('unable to called with null overriding global config option', function(assert) {
   assert.expect(1);
 
-  const view = createView({
+  const view = this.createView({
     template: hbs`{{moment-to-now date allow-empty=false}}`,
     context: {
       date: null


### PR DESCRIPTION
* Extract `moduleForHelper` to DRY up test setup
* Extract `hoursFromNow` to DRY up time arithmetic
* In tests, re-assign `this.container` and `this.registry` depending
  upon what is available