### PR TITLE
Add a service to manage global locale, and to rerender helpers on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,32 +170,45 @@ module.exports = function(environment) {
   };
 ```
 
-### Configure default runtime locale
+### Configure default runtime locale/timeZone
 
-#### Globally
+#### Globally set locale
 
 ```js
 // app/routes/applicaton.js
 export default Ember.Route.extend({
   moment: Ember.inject.service(),
   beforeModel() {
-    this.set('moment.locale', 'es');
+    this.get('moment').changeLocale('es');
+  }
+});
+```
+
+#### Globally set time zone
+
+```js
+// app/routes/applicaton.js
+export default Ember.Route.extend({
+  moment: Ember.inject.service(),
+  beforeModel() {
+    this.get('moment').changeTimeZone('America/Los_Angeles');
   }
 });
 ```
 
 #### Locally
 
-All helpers accept a `locale` argument, which is a string.  This allows for overriding of the global locale.
+All helpers accept a `locale` and `timeZone` argument, which is a string.  This allows for overriding of the global locale.
 
 ```hbs
-{{moment-format date locale='es'}}
-{{moment-duration date locale='es'}}
-{{moment-from-now date locale='es'}}
-{{moment-to-now date locale='es'}}
+{{moment-format date locale='es' timeZone='America/Los_Angeles'}}
+{{moment-duration date locale='es' timeZone='America/Los_Angeles' timeZone='America/Los_Angeles'}}
+{{moment-from-now date locale='es' timeZone='America/Los_Angeles'}}
+{{moment-to-now date locale='es' timeZone='America/Los_Angeles'}}
 ```
 
-Feature set of i18n support within moment can be found here:  http://momentjs.com/docs/#/i18n/
+Documentation on i18n support within moment can be found here:  http://momentjs.com/docs/#/i18n/
+Documentation on timezone within moment can be found here: http://momentjs.com/timezone/docs/
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -176,12 +176,10 @@ module.exports = function(environment) {
 
 ```js
 // app/routes/applicaton.js
-import moment from 'moment';
-
 export default Ember.Route.extend({
+  moment: Ember.inject.service(),
   beforeModel() {
-    // sets the application locale to Spanish
-    moment.locale('es');
+    this.set('moment.locale', 'es');
   }
 });
 ```

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -3,15 +3,27 @@ import Ember from 'ember';
 export default Ember.Helper.extend({
   moment: Ember.inject.service(),
 
-  init() {
-    this._super(...arguments);
-    let service = this.get('moment');
-    service.addObserver('locale', this, this.recompute);
-  },
+  localeDidChange: Ember.observer('moment.locale', function() {
+    this.recompute();
+  }),
 
-  destroy() {
-    let service = this.get('moment');
-    service.removeObserver('locale', this, this.recompute);
-    this._super(...arguments);
+  timeZoneDidChange: Ember.observer('moment.timeZone', function() {
+    this.recompute();
+  }),
+
+  morphMoment(time, { locale, timeZone }) {
+    locale = locale || this.get('moment.locale');
+
+    if (locale) {
+      time = time.locale(locale);
+    }
+
+    timeZone = timeZone || this.get('moment.timeZone');
+
+    if (timeZone && time.tz) {
+      time = time.tz(timeZone);
+    }
+
+    return time;
   }
 });

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Helper.extend({
+  moment: Ember.inject.service(),
+
+  init() {
+    this._super(...arguments);
+    let service = this.get('moment');
+    service.addObserver('locale', this, this.recompute);
+  },
+
+  destroy() {
+    let service = this.get('moment');
+    service.removeObserver('locale', this, this.recompute);
+    this._super(...arguments);
+  }
+});

--- a/addon/helpers/moment-duration.js
+++ b/addon/helpers/moment-duration.js
@@ -2,18 +2,12 @@ import moment from 'moment';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  compute(params, { locale }) {
+  compute(params, { locale, timeZone }) {
     if (!params || params && params.length > 2) {
       throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
     }
 
-    let time = moment.duration(...params);
-
-    locale = locale || this.get('moment.locale');
-
-    if (locale) {
-      time = time.locale(locale);
-    }
+    let time = this.morphMoment(moment.duration(...params), { locale, timeZone });
 
     return time.humanize();
   }

--- a/addon/helpers/moment-duration.js
+++ b/addon/helpers/moment-duration.js
@@ -1,13 +1,15 @@
-import Ember from 'ember';
 import moment from 'moment';
+import BaseHelper from './-base';
 
-export default Ember.Helper.extend({
-  compute: function(params, { locale }) {
+export default BaseHelper.extend({
+  compute(params, { locale }) {
     if (!params || params && params.length > 2) {
       throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
     }
 
     let time = moment.duration(...params);
+
+    locale = locale || this.get('moment.locale');
 
     if (locale) {
       time = time.locale(locale);

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
 import moment from 'moment';
 import computeFn from '../utils/compute-fn';
+import BaseHelper from './-base';
 
-export default Ember.Helper.extend({
+export default BaseHelper.extend({
   globalOutputFormat: 'LLLL',
   globalAllowEmpty: false,
 
@@ -28,6 +28,8 @@ export default Ember.Helper.extend({
     }
 
     let time = moment(...args);
+
+    locale = locale || this.get('moment.locale');
 
     if (locale) {
       time = time.locale(locale);

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -6,35 +6,29 @@ export default BaseHelper.extend({
   globalOutputFormat: 'LLLL',
   globalAllowEmpty: false,
 
-  compute: computeFn(function(params, { locale }) {
+  compute: computeFn(function(params, { locale, timeZone }) {
     const length = params.length;
 
     if (length > 3) {
       throw new TypeError('ember-moment: Invalid Number of arguments, expected at most 3');
     }
 
-    let output;
+    let format;
     const args = [];
 
     args.push(params[0]);
 
     if (length === 1) {
-      output = this.globalOutputFormat;
+      format = this.globalOutputFormat;
     } else if (length === 2) {
-      output = params[1];
+      format = params[1];
     } else if (length > 2) {
       args.push(params[2]);
-      output = params[1];
+      format = params[1];
     }
 
-    let time = moment(...args);
+    let time = this.morphMoment(moment(...args), { locale, timeZone });
 
-    locale = locale || this.get('moment.locale');
-
-    if (locale) {
-      time = time.locale(locale);
-    }
-
-    return time.format(output);
+    return time.format(format);
   })
 });

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -8,20 +8,14 @@ const runBind = Ember.run.bind;
 export default BaseHelper.extend({
   globalAllowEmpty: false,
 
-  compute: computeFn(function(params, { hideSuffix, interval, locale }) {
+  compute: computeFn(function(params, { hideSuffix, interval, locale, timeZone }) {
     this.clearTimer();
 
     if (interval) {
       this.timer = setTimeout(runBind(this, this.recompute), parseInt(interval, 10));
     }
 
-    let time = moment(...params);
-
-    locale = locale || this.get('moment.locale');
-
-    if (locale) {
-      time = time.locale(locale);
-    }
+    let time = this.morphMoment(moment(...params), { locale, timeZone });
 
     return time.fromNow(hideSuffix);
   }),

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 import moment from 'moment';
 import computeFn from '../utils/compute-fn';
+import BaseHelper from './-base';
 
 const runBind = Ember.run.bind;
 
-export default Ember.Helper.extend({
+export default BaseHelper.extend({
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { hideSuffix, interval, locale }) {
@@ -15,6 +16,8 @@ export default Ember.Helper.extend({
     }
 
     let time = moment(...params);
+
+    locale = locale || this.get('moment.locale');
 
     if (locale) {
       time = time.locale(locale);

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 import moment from 'moment';
 import computeFn from '../utils/compute-fn';
+import BaseHelper from './-base';
 
 const runBind = Ember.run.bind;
 
-export default Ember.Helper.extend({
+export default BaseHelper.extend({
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { hidePrefix, interval, locale }) {
@@ -15,6 +16,8 @@ export default Ember.Helper.extend({
     }
 
     let time = moment(...params);
+
+    locale = locale || this.get('moment.locale');
 
     if (locale) {
       time = time.locale(locale);

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -8,20 +8,14 @@ const runBind = Ember.run.bind;
 export default BaseHelper.extend({
   globalAllowEmpty: false,
 
-  compute: computeFn(function(params, { hidePrefix, interval, locale }) {
+  compute: computeFn(function(params, { hidePrefix, interval, locale, timeZone }) {
     this.clearTimer();
 
     if (interval) {
       this.timer = setTimeout(runBind(this, this.recompute), parseInt(interval, 10));
     }
 
-    let time = moment(...params);
-
-    locale = locale || this.get('moment.locale');
-
-    if (locale) {
-      time = time.locale(locale);
-    }
+    let time = this.morphMoment(moment(...params), { locale, timeZone });
 
     return time.toNow(hidePrefix);
   }),

--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import moment from 'moment';
+
+const { computed, defineProperty } = Ember;
+
+export default Ember.Service.extend({
+  init() {
+    this._super(...arguments);
+
+    let locale = null;
+
+    defineProperty(this, 'locale', computed({
+      get() {
+        return locale;
+      },
+      set(property, key) {
+        locale = key;
+        moment.locale(key);
+        return key;
+      }
+    }));
+  },
+
+  moment() {
+    let value = moment(...arguments);
+    let locale = this.get('locale');
+
+    if (locale) {
+      value = moment.locale(locale);
+    }
+
+    return value;
+  }
+});

--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -1,34 +1,57 @@
 import Ember from 'ember';
 import moment from 'moment';
 
-const { computed, defineProperty } = Ember;
+const { computed } = Ember;
 
 export default Ember.Service.extend({
-  init() {
-    this._super(...arguments);
+  _locale: null,
+  _timeZone: null,
 
-    let locale = null;
+  locale: computed({
+    get() {
+      return this.get('_locale');
+    },
+    set(propertyKey, locale) {
+      this.set('_locale', locale);
+      return locale;
+    }
+  }),
 
-    defineProperty(this, 'locale', computed({
-      get() {
-        return locale;
-      },
-      set(property, key) {
-        locale = key;
-        moment.locale(key);
-        return key;
+  timeZone: computed({
+    get() {
+      return this.get('_timeZone');
+    },
+    set(propertyKey, timeZone) {
+      if (moment.tz) {
+        this.set('_timeZone', timeZone);
+        return timeZone;
+      } else {
+        Ember.Logger.warn('[ember-moment] attempted to set timezone, but moment-timezone unavailable.');
       }
-    }));
+    }
+  }),
+
+  changeLocale(locale) {
+    this.set('locale', locale);
+  },
+
+  changeTimeZone(timeZone) {
+    this.set('timeZone', timeZone);
   },
 
   moment() {
-    let value = moment(...arguments);
+    let time = moment(...arguments);
     let locale = this.get('locale');
+    let timeZone = this.get('timeZone');
 
     if (locale) {
-      value = moment.locale(locale);
+      time = time.locale(locale);
     }
 
-    return value;
+    if (timeZone && time.tz) {
+      time = time.tz(timeZone);
+    }
+
+    return time;
   }
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -7,7 +7,7 @@ export default Ember.Controller.extend({
   moment: Ember.inject.service(),
   actions: {
     changeLocale(locale) {
-      this.set('moment.locale', locale);
+      this.get('moment').changeLocale(locale);
     }
   },
   emptyDate: null,

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -4,6 +4,12 @@ import momentFormat from 'ember-moment/computeds/format';
 import momentFromNow from 'ember-moment/computeds/from-now';
 
 export default Ember.Controller.extend({
+  moment: Ember.inject.service(),
+  actions: {
+    changeLocale(locale) {
+      this.set('moment.locale', locale);
+    }
+  },
   emptyDate: null,
   now: new Date(),
   lastHour: new Date(new Date().valueOf() - (60*60*1000)),

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
-import moment from 'moment';
 
 export default Ember.Route.extend({
-  setupController: function (controller, model) {
-    moment.locale('en');
+  moment: Ember.inject.service(),
+
+  beforeModel() {
+    this.set('moment.locale', 'en');
+  },
+
+  setupController(controller, model) {
     this._super(controller, model);
 
     setInterval(function () {

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,3 +1,7 @@
+<button {{action 'changeLocale' 'es'}}>ES</button>
+<button {{action 'changeLocale' 'fr'}}>FR</button>
+<button {{action 'changeLocale' 'en'}}>EN</button>
+
 {{moment-format now 'LLLL'}}
 <code>
   \{{moment-format now 'LLLL'}}

--- a/tests/unit/helpers/moment-duration-test.js
+++ b/tests/unit/helpers/moment-duration-test.js
@@ -3,7 +3,9 @@ import { test } from 'ember-qunit';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 import moduleForHelper from '../../helpers/module-for-helper';
 
-moduleForHelper('moment-duration');
+moduleForHelper('moment-duration', {
+  needs: ['service:moment']
+});
 
 test('one arg (ms)', function(assert) {
   assert.expect(1);

--- a/tests/unit/helpers/moment-format-test.js
+++ b/tests/unit/helpers/moment-format-test.js
@@ -95,6 +95,34 @@ test('can inline a locale instead of using global locale', function(assert) {
   runDestroy(view);
 });
 
+test('can inline timeZone (New York)', function(assert) {
+  assert.expect(1);
+  const view = this.createView({
+    template: hbs`{{moment-format date 'LLLL' timeZone='America/New_York'}}`,
+    context: {
+      date: 0
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'Wednesday, December 31, 1969 7:00 PM');
+  runDestroy(view);
+});
+
+test('can inline timeZone (Los Angeles)', function(assert) {
+  assert.expect(1);
+  const view = this.createView({
+    template: hbs`{{moment-format date 'LLLL' timeZone='America/Los_Angeles'}}`,
+    context: {
+      date: 0
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'Wednesday, December 31, 1969 4:00 PM');
+  runDestroy(view);
+});
+
 test('can be called with null when allow-empty is set to true', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/helpers/moment-format-test.js
+++ b/tests/unit/helpers/moment-format-test.js
@@ -5,7 +5,9 @@ import date from '../../helpers/date';
 import moduleForHelper from '../../helpers/module-for-helper';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
-moduleForHelper('moment-format');
+moduleForHelper('moment-format', {
+  needs: ['service:moment']
+});
 
 test('one arg (date)', function(assert) {
   assert.expect(1);

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -5,7 +5,9 @@ import moduleForHelper from '../../helpers/module-for-helper';
 import hoursFromNow from '../../helpers/hours-from-now';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
-moduleForHelper('moment-from-now');
+moduleForHelper('moment-from-now',{
+  needs: ['service:moment']
+});
 
 test('one arg (date)', function(assert) {
   assert.expect(1);

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -5,7 +5,9 @@ import moduleForHelper from '../../helpers/module-for-helper';
 import hoursFromNow from '../../helpers/hours-from-now';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
-moduleForHelper('moment-to-now');
+moduleForHelper('moment-to-now', {
+  needs: ['service:moment']
+});
 
 test('one arg (date)', function(assert) {
   assert.expect(1);


### PR DESCRIPTION
Give the following action, when invoked, will rerender all helpers which are using the global locale (ie, a locale was not passed as an attr).

Triggering a rerender of all helpers:

```js
export default Ember.Controller.extend({
  moment: Ember.inject.service(),
  actions: {
    changeLocale(locale) {
      this.get('moment').changeLocale(locale);
    } 
});
````

Setting application-wide locale:
```js
// app/routes/application.js
export default Ember.Route.extend({
  moment: Ember.inject.service(),
  beforeModel() {
    // default application-wide locale is spanish
    this.get('moment').changeLocale('es');
  }
});
```

Thoughts @stefanpenner ?

Part of #104