### PR TITLE
Make it possible to change the default date format

### DIFF
--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -11,6 +11,10 @@ export default Ember.Helper.extend({
     this.recompute();
   }),
 
+  defaultFormatDidChange: Ember.observer('moment.defaultFormat', function() {
+    this.recompute();
+  }),
+
   morphMoment(time, { locale, timeZone }) {
     locale = locale || this.get('moment.locale');
 

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -1,9 +1,12 @@
+import Ember from "ember";
 import moment from 'moment';
 import computeFn from '../utils/compute-fn';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  globalOutputFormat: Ember.computed.oneWay("moment.defaultFormat"),
+  globalOutputFormat: Ember.computed("moment.defaultFormat", function() {
+    return this.get("moment.defaultFormat") || "LLLL";
+  }),
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { locale, timeZone }) {

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -3,7 +3,7 @@ import computeFn from '../utils/compute-fn';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  globalOutputFormat: 'LLLL',
+  globalOutputFormat: Ember.computed.oneWay("moment.defaultFormat"),
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { locale, timeZone }) {
@@ -19,7 +19,7 @@ export default BaseHelper.extend({
     args.push(params[0]);
 
     if (length === 1) {
-      format = this.globalOutputFormat;
+      format = this.get("globalOutputFormat");
     } else if (length === 2) {
       format = params[1];
     } else if (length > 2) {

--- a/app/helpers/moment-format.js
+++ b/app/helpers/moment-format.js
@@ -3,6 +3,5 @@ import config from '../config/environment';
 import Helper from 'ember-moment/helpers/moment-format';
 
 export default Helper.extend({
-  globalOutputFormat: Ember.get(config, 'moment.outputFormat'),
   globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
 });

--- a/app/instance-initializers/moment-default-format.js
+++ b/app/instance-initializers/moment-default-format.js
@@ -1,0 +1,13 @@
+import Ember from "ember";
+import config from '../config/environment';
+
+export function initialize(instance) {
+  const momentService = instance.container.lookup("service:moment");
+  let defaultFormat = Ember.get(config, 'moment.outputFormat');
+  momentService.changeDefaultFormat(defaultFormat || "LLLL");
+}
+
+export default {
+  name: 'moment-default-format',
+  initialize
+};

--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -6,6 +6,7 @@ const { computed } = Ember;
 export default Ember.Service.extend({
   _locale: null,
   _timeZone: null,
+  _defaultFormat: null,
 
   locale: computed({
     get() {
@@ -31,12 +32,26 @@ export default Ember.Service.extend({
     }
   }),
 
+  defaultFormat: computed({
+    get() {
+      return this.get('_defaultFormat');
+    },
+    set(propertyKey, defaultFormat) {
+      this.set('_defaultFormat', defaultFormat);
+      return defaultFormat;
+    }
+  }),
+
   changeLocale(locale) {
     this.set('locale', locale);
   },
 
   changeTimeZone(timeZone) {
     this.set('timeZone', timeZone);
+  },
+
+  changeDefaultFormat(defaultFormat) {
+    this.set('defaultFormat', defaultFormat);
   },
 
   moment() {

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -8,6 +8,9 @@ export default Ember.Controller.extend({
   actions: {
     changeLocale(locale) {
       this.get('moment').changeLocale(locale);
+    },
+    changeDefaultFormat(defaultFormat) {
+      this.get('moment').changeDefaultFormat(defaultFormat);
     }
   },
   emptyDate: null,

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,10 +1,26 @@
+Locale:
 <button {{action 'changeLocale' 'es'}}>ES</button>
 <button {{action 'changeLocale' 'fr'}}>FR</button>
 <button {{action 'changeLocale' 'en'}}>EN</button>
 
+<hr>
+Default Format:
+<button {{action 'changeDefaultFormat' 'LLLL'}}>LLLL</button>
+<button {{action 'changeDefaultFormat' 'DD.MM.YYYY'}}>DD.MM.YYYY</button>
+<button {{action 'changeDefaultFormat' 'LL'}}>LL</button>
+
+<hr>
+
 {{moment-format now 'LLLL'}}
 <code>
   \{{moment-format now 'LLLL'}}
+</code>
+
+<hr>
+
+{{moment-format now}}
+<code>
+  \{{moment-format now}}
 </code>
 
 <hr>


### PR DESCRIPTION
This PR adds a `changeDefaultFormat` function to the moment service, as explained in #121. In order to stay compatible with the current way of setting a default format (in the config/environment.js), an instance initializer has been added to set the default format to the one specified there.

This means that the default format used by `{{moment-format myDate}}` can be changed at any time by calling:

```js
this.get("moment").changeDefaultFormat("DD.MM.YYYY");
```