### PR TITLE
Adding locale and moment computeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 
 ## Usage
 
-### Helpers
+## Computed Property Macros
+
+Ships with the following computed property macros: `duration`, `humanize`, `locale`, `tz`, `format`, `calendar`, `moment`, `toNow`, `fromNow`.  They can be used individually or composed together.
+
+[Computed Property Macro Documentation](https://github.com/stefanpenner/ember-moment/wiki/Computed-Property-Macros)
+
+## Helpers
 
 ```hbs
 {{moment-format date}}
@@ -26,49 +32,7 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 {{moment-to-now date}}
 {{moment-duration ms}}
 {{moment-calendar date}}
-```
 
-### Computed Property Macros
-
-Ships with the following computed property macros: `duration`, `humanize`, `locale`, `format`, `moment`, `toNow`, `fromNow`.  They can be used individually or composed together.
-
-[Full API Documentation](https://github.com/stefanpenner/ember-moment/wiki/Computed-Property-Macros)
-
-#### Moment & Format Computed
-
-Behaves like `moment()` and will return a moment object.  All arguments of the underlying API are supported.
-
-```js
-import momentComputed from 'ember-moment/computeds/moment';
-import format from 'ember-moment/computeds/format';
-
-export default Ember.Component.extend({
-  createdOn: new Date('01/02/2016'),
-  createdOnFormatted: format(momentComputed('createdOn'), 'MMMM DD, YYYY')
-});
-```
-
-#### i18n/Locale
-
-Locale takes a moment object and apply a locale to that instance
-
-```js
-import momentComputed from 'ember-moment/computeds/moment';
-import format from 'ember-moment/computeds/format';
-import locale from 'ember-moment/computeds/locale';
-
-export default Ember.Component.extend({
-  moment: Ember.inject.service(),
-  createdOn: new Date('01/02/2016'),
-  createdOnFormatted: format(locale(momentComputed('createdOn'), 'moment.locale'), 'MMMM DD, YYYY')
-});
-```
-
-## Advanced Usage
-
-### Helpers
-
-```hbs
 {{moment-format date outputFormat inputFormat}}
 {{moment-from-now date}}
 {{moment-to-now date}}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 
 ## Usage
 
+### Helpers
+
 ```hbs
 {{moment-format date}}
 {{moment-from-now date}}
@@ -25,7 +27,45 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 {{moment-duration ms}}
 ```
 
-### Advanced Usage
+### Computed Property Macros
+
+Ships with the following computed property macros: `duration`, `humanize`, `locale`, `format`, `moment`, `toNow`, `fromNow`.  They can be used individually or composed together.
+
+[Full API Documentation](https://github.com/stefanpenner/ember-moment/wiki/Computed-Property-Macros)
+
+#### Moment & Format Computed
+
+Behaves like `moment()` and will return a moment object.  All arguments of the underlying API are supported.
+
+```js
+import momentComputed from 'ember-moment/computeds/moment';
+import format from 'ember-moment/computeds/format';
+
+export default Ember.Component.extend({
+  createdOn: new Date('01/02/2016'),
+  createdOnFormatted: format(momentComputed('createdOn'), 'MMMM DD, YYYY')
+});
+```
+
+#### i18n/Locale
+
+Locale takes a moment object and apply a locale to that instance
+
+```js
+import momentComputed from 'ember-moment/computeds/moment';
+import format from 'ember-moment/computeds/format';
+import locale from 'ember-moment/computeds/locale';
+
+export default Ember.Component.extend({
+  moment: Ember.inject.service(),
+  createdOn: new Date('01/02/2016'),
+  createdOnFormatted: format(locale(momentComputed('createdOn'), 'moment.locale'), 'MMMM DD, YYYY')
+});
+```
+
+## Advanced Usage
+
+### Helpers
 
 ```hbs
 {{moment-format date outputFormat inputFormat}}
@@ -48,41 +88,9 @@ Recomputes the time ago every 1-second (1000 milliseconds).  This is useful for 
 ## ES6 Moment
 
 This addon provides the ability to import moment as an ES6 module.
+
 ```js
 import moment from 'moment';
-```
-
-## Computed Macro
-
-```js
-import momentDuration from 'ember-moment/computeds/duration';
-import momentFormat from 'ember-moment/computeds/format';
-import momentFromNow from 'ember-moment/computeds/from-now';
-import momentToNow from 'ember-moment/computeds/to-now';
-
-export default Ember.Controller.extend({
-  date: new Date('2013-02-08T09:30:26'),
-
-  // Takes on the behavior of moment().format()
-  // http://momentjs.com/docs/#/displaying/format/
-  shortDate: momentFormat('date', 'MM/DD/YYYY'),
-
-  // first param: date input
-  // second param: date format http://momentjs.com/docs/#/parsing/string-format/ (optional)
-  // third param: hide suffix (optional, false by default)
-  // http://momentjs.com/docs/#/displaying/fromnow/
-  timeSince: momentFromNow("12-25-1995", "MM-DD-YYYY", false), // -> output: "2 years ago"
-
-  // first param: date input
-  // second param: date format http://momentjs.com/docs/#/parsing/string-format/ (optional)
-  // third param: hide prefix (optional, false by default)
-  // http://momentjs.com/docs/#/displaying/tonow
-  computedNumHours: momentToNow("12-25-1995", "MM-DD-YYYY", false), // -> output: "in 20 years"
-
-  // duration units: seconds, minutes, hours, days, weeks, months, years
-  // http://momentjs.com/docs/#/durations/
-  computedNumHours: momentDuration(10, 'hours')
-});
 ```
 
 ## Include Moment Timezone

--- a/addon/computeds/-base.js
+++ b/addon/computeds/-base.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 import getValue from '../utils/get-value';
 import getDependentKeys from '../utils/get-dependent-keys';
 
+const { computed } = Ember;
+
 export default function computedFactory(fn) {
   return function(...args) {
     const computedArgs = [].concat(getDependentKeys(args));
@@ -13,6 +15,6 @@ export default function computedFactory(fn) {
       return fn.call(this, params);
     });
 
-    return Ember.computed(...computedArgs);
+    return computed(...computedArgs);
   };
 }

--- a/addon/computeds/calendar.js
+++ b/addon/computeds/calendar.js
@@ -7,7 +7,7 @@ export default computedFactory(function calendarComputed(params) {
 		throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
 	}
 
-	const [date, referenceTime] = params;
+	const [ date, referenceTime ] = params;
 
   return moment(date).calendar(referenceTime);
 });

--- a/addon/computeds/calendar.js
+++ b/addon/computeds/calendar.js
@@ -1,0 +1,13 @@
+import moment from 'moment';
+
+import computedFactory from './-base';
+
+export default computedFactory(function calendarComputed(params) {
+	if (!params || params && params.length > 2) {
+		throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
+	}
+
+	const [date, referenceTime] = params;
+
+  return moment(date).calendar(referenceTime);
+});

--- a/addon/computeds/duration.js
+++ b/addon/computeds/duration.js
@@ -3,5 +3,5 @@ import moment from 'moment';
 import computedFactory from './-base';
 
 export default computedFactory(function durationComputed(params) {
-	return moment.duration(...params).humanize();
+  return moment.duration(...params);
 });

--- a/addon/computeds/format.js
+++ b/addon/computeds/format.js
@@ -5,27 +5,20 @@ import getOwner from 'ember-getowner-polyfill';
 import computedFactory from './-base';
 
 const CONFIG_KEY = 'config:environment';
+const { get } = Ember;
 
-const { get, assert } = Ember;
+export default computedFactory(function formatComtputed([value, optionalFormat]) {
+  if (!optionalFormat) {
+    const owner = getOwner(this);
 
-export default computedFactory(function formatComputed(params) {
-  assert('At least one datetime argument required for moment computed', params.length);
+    if (owner && owner.hasRegistration && owner.hasRegistration(CONFIG_KEY)) {
+      const config = owner.resolveRegistration(CONFIG_KEY);
 
-  const owner = getOwner(this);
-  const momentArgs = [params[0]];
-
-  let maybeOutputFormat = params[1];
-
-  if (params.length > 2) {
-    momentArgs.push(params[2]);
-  }
-  else if (owner && owner.hasRegistration && owner.hasRegistration(CONFIG_KEY)) {
-    const config = owner.resolveRegistration(CONFIG_KEY);
-
-    if (config) {
-      maybeOutputFormat = get(config, 'moment.outputFormat');
+      if (config) {
+        optionalFormat = get(config, 'moment.outputFormat');
+      }
     }
   }
 
-  return moment.apply(this, momentArgs).format(maybeOutputFormat);
+  return moment(value).format(optionalFormat);
 });

--- a/addon/computeds/from-now.js
+++ b/addon/computeds/from-now.js
@@ -5,7 +5,7 @@ import computedFactory from './-base';
 export default computedFactory(function fromNowComputed(params) {
   let maybeHideSuffix;
 
-  if (params.length > 2) {
+  if (params.length > 1) {
     maybeHideSuffix = params.pop();
   }
 

--- a/addon/computeds/humanize.js
+++ b/addon/computeds/humanize.js
@@ -1,0 +1,10 @@
+import moment from 'moment';
+import computedFactory from './-base';
+
+export default computedFactory(function humanizeComputed([duration, suffixless]) {
+  if (!moment.isDuration(duration)) {
+    duration = moment.duration(duration);
+  }
+
+  return duration.humanize(suffixless);
+});

--- a/addon/computeds/locale.js
+++ b/addon/computeds/locale.js
@@ -1,0 +1,11 @@
+import moment from 'moment';
+
+import computedFactory from './-base';
+
+export default computedFactory(function localeComputed([value, locale]) {
+  if (moment.isMoment(value)) {
+    value = moment(value);
+  }
+
+  return value.locale(locale);
+});

--- a/addon/computeds/locale.js
+++ b/addon/computeds/locale.js
@@ -2,10 +2,10 @@ import moment from 'moment';
 
 import computedFactory from './-base';
 
-export default computedFactory(function localeComputed([value, locale]) {
-  if (moment.isMoment(value)) {
-    value = moment(value);
+export default computedFactory(function localeComputed([date, locale]) {
+  if (!moment.isDuration(date)) {
+    date = moment(date);
   }
 
-  return value.locale(locale);
+  return date.locale(locale);
 });

--- a/addon/computeds/moment.js
+++ b/addon/computeds/moment.js
@@ -1,0 +1,7 @@
+import moment from 'moment';
+
+import computedFactory from './-base';
+
+export default computedFactory(function momentComputed(params) {
+  return moment(...params);
+});

--- a/addon/computeds/to-now.js
+++ b/addon/computeds/to-now.js
@@ -5,7 +5,7 @@ import computedFactory from './-base';
 export default computedFactory(function toNowComputed(params) {
   let maybeHidePrefix;
 
-  if (params.length > 2) {
+  if (params.length > 1) {
     maybeHidePrefix = params.pop();
   }
 

--- a/addon/computeds/tz.js
+++ b/addon/computeds/tz.js
@@ -1,0 +1,11 @@
+import moment from 'moment';
+
+import computedFactory from './-base';
+
+export default computedFactory(function tzComputed([value, tz]) {
+  if (moment.isMoment(value)) {
+    value = moment(value);
+  }
+
+  return value.tz(tz);
+});

--- a/addon/computeds/tz.js
+++ b/addon/computeds/tz.js
@@ -2,10 +2,6 @@ import moment from 'moment';
 
 import computedFactory from './-base';
 
-export default computedFactory(function tzComputed([value, tz]) {
-  if (moment.isMoment(value)) {
-    value = moment(value);
-  }
-
-  return value.tz(tz);
+export default computedFactory(function tzComputed([date, tz]) {
+  return moment(date).tz(tz);
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
-import momentDuration from 'ember-moment/computeds/duration';
-import momentFormat from 'ember-moment/computeds/format';
-import momentFromNow from 'ember-moment/computeds/from-now';
+import duration from 'ember-moment/computeds/duration';
+import format from 'ember-moment/computeds/format';
+import fromNow from 'ember-moment/computeds/from-now';
+import locale from 'ember-moment/computeds/locale';
+import humanize from 'ember-moment/computeds/humanize';
+import momentComputed from 'ember-moment/computeds/moment';
 
 export default Ember.Controller.extend({
   moment: Ember.inject.service(),
@@ -18,8 +21,8 @@ export default Ember.Controller.extend({
   lastHour: new Date(new Date().valueOf() - (60*60*1000)),
   date: new Date(),
   numHours: 822,
-  computedDate: momentFormat('date'),
-  computedOneHourAgo: momentFromNow('lastHour'),
-  computedNumHours: momentDuration('numHours', 'hours'),
+  computedDate: format(locale(momentComputed('date'), 'moment.locale')),
+  computedOneHourAgo: fromNow(locale(momentComputed('lastHour'), 'moment.locale')),
+  computedNumHours: humanize(locale(duration('numHours', 'hours'), 'moment.locale')),
   usIndependenceDay: new Date(1776, 6, 4, 12, 0, 0)
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,3 +1,16 @@
 html, body {
   margin: 20px;
+  font-family: Helvetica, sans-serif;
+  font-size: 14px;
+}
+
+.example {
+  padding: 5px;
+  margin: 2px 0;
+  background: #f1f1f1;
+}
+
+code {
+  color: #333;
+  font-size: 13px;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,3 @@
-<h2 id="title">Welcome to Ember.js</h2>
+<h2 id="title">ember-moment</h2>
 
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -11,124 +11,34 @@ Default Format:
 
 <hr>
 
-{{moment-format now 'LLLL'}}
-<code>
-  \{{moment-format now 'LLLL'}}
-</code>
+<h3>Format</h3>
+
+{{partial 'partials/format'}}
 
 <hr>
 
-{{moment-format now}}
-<code>
-  \{{moment-format now}}
-</code>
+<h3>From Now</h3>
+
+{{partial 'partials/from-now'}}
+
+<h3>To Now</h3>
+
+{{partial 'partials/to-now'}}
 
 <hr>
 
-{{moment-format usIndependenceDay 'LLLL'}}
-<code>
-  \{{moment-format usIndependenceDay 'LLLL'}}
-</code>
+<h3>Calendar</h3>
+
+{{partial 'partials/calendar'}}
 
 <hr>
 
-{{moment-format usIndependenceDay 'MMM DD, YYYY'}}
-<code>
-  \{{moment-format usIndependenceDay 'MMM DD, YYYY'}}
-</code>
+<h3>Duration</h3>
+
+{{partial 'partials/duration'}}
 
 <hr>
 
-{{moment-format now 'LL' 'LLLL'}}
-<code>
-  \{{moment-format now 'LL' 'LLLL'}}
-</code>
+<h3>Computed Property Macros</h3>
 
-<hr>
-
-{{moment-from-now now}}
-<code>
-  \{{moment-from-now now}}
-</code>
-
-<hr>
-
-{{moment-from-now lastHour interval=1000}}
-<code>
-  \{{moment-from-now lastHour interval=1000}}
-</code>
-
-<hr>
-
-{{moment-from-now usIndependenceDay}}
-<code>
-  \{{moment-from-now usIndependenceDay}}
-</code>
-
-<hr>
-
-{{moment-duration 5000}}
-<code>
-  \{{moment-duration 5000}}
-</code>
-
-<hr>
-
-{{moment-duration 600000}}
-<code>
-  \{{moment-duration 600000}}
-</code>
-
-<hr>
-
-{{moment-duration 86400000}}
-<code>
-  \{{moment-duration 86400000}}
-</code>
-
-<hr>
-
-{{moment-duration '7.23:59:59'}}
-<code>
-  \{{moment-duration '7.23:59:59'}}
-</code>
-
-<hr>
-
-{{moment-duration 210 'days'}}
-<code>
-  \{{moment-duration 210 'days'}}
-</code>
-
-<hr>
-
-{{computedDate}}
-<br />
-<code>
-  export default Ember.Controller.extend({<br />
-    date: new Date(), /* in the route I am looping this */ <br />
-    computedDate: moment('date', 'MM/DD/YY hh:mm:ss')<br />
-  });
-</code>
-
-<hr>
-
-{{computedOneHourAgo}}
-<br />
-<code>
-  export default Ember.Controller.extend({<br />
-    lastHour: new Date(new Date().valueOf() - (60*60*1000)),<br />
-    computedOneHourAgo: ago('lastHour', 'MM/DD/YY hh:mm:ss')<br />
-  });
-</code>
-
-<hr>
-
-{{computedNumHours}}
-<br />
-<code>
-  export default Ember.Controller.extend({<br />
-    numHours: 822,<br />
-    computedNumHours: duration('numHours', 'hours'),<br />
-  });
-</code>
+{{partial 'partials/cps'}}

--- a/tests/dummy/app/templates/partials/calendar.hbs
+++ b/tests/dummy/app/templates/partials/calendar.hbs
@@ -1,0 +1,6 @@
+<div class="example">
+{{moment-calendar now lastHour}}
+<code>
+  \{{moment-calendar now lastHour}}
+</code>
+</div>

--- a/tests/dummy/app/templates/partials/cps.hbs
+++ b/tests/dummy/app/templates/partials/cps.hbs
@@ -1,0 +1,32 @@
+<div class="example">
+{{computedDate}}
+<br /><br />
+<code>
+  export default Ember.Controller.extend({<br />
+    date: new Date(), /* in the route I am looping this */ <br />
+    computedDate: moment('date', 'MM/DD/YY hh:mm:ss')<br />
+  });
+</code>
+</div>
+
+<div class="example">
+{{computedOneHourAgo}}
+<br /><br />
+<code>
+  export default Ember.Controller.extend({<br />
+    lastHour: new Date(new Date().valueOf() - (60*60*1000)),<br />
+    computedOneHourAgo: ago('lastHour', 'MM/DD/YY hh:mm:ss')<br />
+  });
+</code>
+</div>
+
+<div class="example">
+{{computedNumHours}}
+<br /><br />
+<code>
+  export default Ember.Controller.extend({<br />
+    numHours: 822,<br />
+    computedNumHours: duration('numHours', 'hours'),<br />
+  });
+</code>
+</div>

--- a/tests/dummy/app/templates/partials/duration.hbs
+++ b/tests/dummy/app/templates/partials/duration.hbs
@@ -1,0 +1,34 @@
+<div class="example">
+{{moment-duration 5000}}
+<code>
+  \{{moment-duration 5000}}
+</code>
+</div>
+
+<div class="example">
+{{moment-duration 600000}}
+<code>
+  \{{moment-duration 600000}}
+</code>
+</div>
+
+<div class="example">
+{{moment-duration 86400000}}
+<code>
+  \{{moment-duration 86400000}}
+</code>
+</div>
+
+<div class="example">
+{{moment-duration '7.23:59:59'}}
+<code>
+  \{{moment-duration '7.23:59:59'}}
+</code>
+</div>
+
+<div class="example">
+{{moment-duration 210 'days'}}
+<code>
+  \{{moment-duration 210 'days'}}
+</code>
+</div>

--- a/tests/dummy/app/templates/partials/format.hbs
+++ b/tests/dummy/app/templates/partials/format.hbs
@@ -1,0 +1,34 @@
+<div class="example">
+{{moment-format now 'LLLL'}}
+<code>
+  \{{moment-format now 'LLLL'}}
+</code>
+</div>
+
+<div class="example">
+{{moment-format now}}
+<code>
+  \{{moment-format now}}
+</code>
+</div>
+
+<div class="example">
+{{moment-format usIndependenceDay 'LLLL'}}
+<code>
+  \{{moment-format usIndependenceDay 'LLLL'}}
+</code>
+</div>
+
+<div class="example">
+{{moment-format usIndependenceDay 'MMM DD, YYYY'}}
+<code>
+  \{{moment-format usIndependenceDay 'MMM DD, YYYY'}}
+</code>
+</div>
+
+<div class="example">
+{{moment-format now 'LL' 'LLLL'}}
+<code>
+  \{{moment-format now 'LL' 'LLLL'}}
+</code>
+</div>

--- a/tests/dummy/app/templates/partials/from-now.hbs
+++ b/tests/dummy/app/templates/partials/from-now.hbs
@@ -1,0 +1,20 @@
+<div class="example">
+{{moment-from-now now}}
+<code>
+  \{{moment-from-now now}}
+</code>
+</div>
+
+<div class="example">
+{{moment-from-now lastHour interval=1000}}
+<code>
+  \{{moment-from-now lastHour interval=1000}}
+</code>
+</div>
+
+<div class="example">
+{{moment-from-now usIndependenceDay}}
+<code>
+  \{{moment-from-now usIndependenceDay}}
+</code>
+</div>

--- a/tests/dummy/app/templates/partials/to-now.hbs
+++ b/tests/dummy/app/templates/partials/to-now.hbs
@@ -1,0 +1,20 @@
+<div class="example">
+{{moment-to-now now}}
+<code>
+  \{{moment-to-now now}}
+</code>
+</div>
+
+<div class="example">
+{{moment-to-now lastHour interval=1000}}
+<code>
+  \{{moment-to-now lastHour interval=1000}}
+</code>
+</div>
+
+<div class="example">
+{{moment-to-now usIndependenceDay}}
+<code>
+  \{{moment-to-now usIndependenceDay}}
+</code>
+</div>

--- a/tests/helpers/hours-from-now.js
+++ b/tests/helpers/hours-from-now.js
@@ -1,3 +1,0 @@
-export default function(hours) {
-  return new Date(new Date().valueOf() + (60*60*1000*hours));
-}

--- a/tests/unit/computeds/calendar-test.js
+++ b/tests/unit/computeds/calendar-test.js
@@ -1,0 +1,45 @@
+import Ember from 'ember';
+import moment from 'moment';
+import getOwner from 'ember-getowner-polyfill';
+import { moduleFor, test } from 'ember-qunit';
+import calendar from 'ember-moment/computeds/calendar';
+import tz from 'ember-moment/computeds/tz';
+import locale from 'ember-moment/computeds/locale';
+
+moduleFor('ember-moment@computed:moment', {
+  setup() {
+    this.register('object:empty', Ember.Object.extend({}));
+    moment.locale('en');
+  }
+});
+
+function createSubject(attrs) {
+  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+    container: this.container,
+    registry: this.registry
+  })).create();
+}
+
+test('two args (date, referenceDate)', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+		date: tz(moment('2013-01-01T02:30:26Z'), 'America/New_York'),
+		referenceDate: moment('2013-01-01T12:00:00Z'),
+    computedDate: calendar('date', 'referenceDate')
+  });
+
+  assert.equal(subject.get('computedDate'), 'Yesterday at 9:30 PM');
+});
+
+test('with es locale', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    date: tz(locale(moment('2013-01-01T08:30:26Z'), 'es'), 'America/New_York'),
+    referenceDate: locale(moment('2013-01-01T12:00:00Z'), 'es'),
+    computedDate: calendar('date', 'referenceDate')
+  });
+
+  assert.equal(subject.get('computedDate'), 'hoy a las 3:30');
+});

--- a/tests/unit/computeds/duration-test.js
+++ b/tests/unit/computeds/duration-test.js
@@ -2,7 +2,9 @@ import Ember from 'ember';
 import moment from 'moment';
 import getOwner from 'ember-getowner-polyfill';
 import { moduleFor, test } from 'ember-qunit';
-import computedDuration from 'ember-moment/computeds/duration';
+import duration from 'ember-moment/computeds/duration';
+import humanize from 'ember-moment/computeds/humanize';
+import locale from 'ember-moment/computeds/locale';
 
 moduleFor('ember-moment@computed:duration', {
   setup() {
@@ -11,7 +13,7 @@ moduleFor('ember-moment@computed:duration', {
   }
 });
 
-function createSubject(attrs={}) {
+function createSubject(attrs) {
   return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
     container: this.container,
     registry: this.registry
@@ -23,7 +25,7 @@ test('get and set (ms)', function(assert) {
 
   const subject = createSubject.call(this, {
     ms: 5000,
-    duration: computedDuration('ms')
+    duration: humanize(duration('ms'))
   });
 
   assert.equal(subject.get('duration'), 'a few seconds');
@@ -31,12 +33,25 @@ test('get and set (ms)', function(assert) {
   assert.equal(subject.get('duration'), '3 hours');
 });
 
+test('computed composition using locale and humanize', function(assert) {
+  assert.expect(2);
+
+  const subject = createSubject.call(this, {
+    ms: 5000,
+    duration: humanize(locale(duration('ms'), 'es'))
+  });
+
+  assert.equal(subject.get('duration'), 'unos segundos');
+  subject.set('ms', 10800000);
+  assert.equal(subject.get('duration'), '3 horas');
+});
+
 test('get and set (days)', function(assert) {
   assert.expect(2);
 
   const subject = createSubject.call(this, {
     numDays: 4,
-    duration: computedDuration('numDays', 'days')
+    duration: humanize(duration('numDays', 'days'))
   });
 
   assert.equal(subject.get('duration'), '4 days');
@@ -48,7 +63,7 @@ test('get literal (ms)', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    duration: computedDuration(5000)
+    duration: humanize(duration(5000))
   });
 
   assert.equal(subject.get('duration'), 'a few seconds');

--- a/tests/unit/computeds/format-test.js
+++ b/tests/unit/computeds/format-test.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import moment from 'moment';
 import getOwner from 'ember-getowner-polyfill';
 import { moduleFor, test } from 'ember-qunit';
-import momentFormat from 'ember-moment/computeds/format';
+import format from 'ember-moment/computeds/format';
+import momentComputed from 'ember-moment/computeds/moment';
 import date from '../../helpers/date';
 
 moduleFor('ember-moment@computed:format', {
@@ -15,10 +16,10 @@ moduleFor('ember-moment@computed:format', {
 const { observer, computed } = Ember;
 const { alias } = computed;
 
-function createSubject(attrs = {}) {
+function createSubject(attrs) {
   return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend({
     date: date(0),
-    shortDate: momentFormat('date', 'MM/DD'),
+    shortDate: format('date', 'MM/DD'),
     container: this.container,
     registry: this.registry
   }, attrs)).create();
@@ -29,7 +30,18 @@ test('get value as dependent key, format as dependent key', function(assert) {
 
   const subject = createSubject.call(this, {
     dateFormat: 'MM/DD',
-    shortDate: momentFormat('date', 'dateFormat')
+    shortDate: format('date', 'dateFormat')
+  });
+
+  assert.equal(subject.get('shortDate'), '12/31');
+});
+
+test('composition with moment computed: get value as dependent key, format as dependent key', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    dateFormat: 'MM/DD',
+    shortDate: format(momentComputed('date'), 'dateFormat')
   });
 
   assert.equal(subject.get('shortDate'), '12/31');
@@ -45,7 +57,7 @@ test('get literal', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    shortDate: momentFormat(date(0), 'MM/DD')
+    shortDate: format(date(0), 'MM/DD')
   });
 
   assert.equal(subject.get('shortDate'), '12/31');
@@ -57,7 +69,7 @@ test('single argument supported', function(assert) {
   const timestamp = date(0);
 
   const subject = createSubject.call(this, {
-    shortDate: momentFormat(timestamp)
+    shortDate: format(timestamp)
   });
 
   assert.equal(subject.get('shortDate'), moment(timestamp).format());
@@ -81,7 +93,19 @@ test('is computed handled', function(assert) {
   const subject = createSubject.call(this, {
     _format: 'MM/DD',
     format: alias('_format'),
-    shortDate: momentFormat('date', 'format')
+    shortDate: format('date', 'format')
+  });
+  assert.equal(subject.get('shortDate'), '12/31');
+  subject.set('_format', 'MM');
+  assert.equal(subject.get('shortDate'), '12');
+});
+
+test('composition with moment compouted: is computed handled', function(assert) {
+  assert.expect(2);
+  const subject = createSubject.call(this, {
+    _format: 'MM/DD',
+    format: alias('_format'),
+    shortDate: format(momentComputed('date'), 'format')
   });
   assert.equal(subject.get('shortDate'), '12/31');
   subject.set('_format', 'MM');
@@ -99,7 +123,7 @@ test('outputFormat  option is respected', function(assert) {
 
   const subject = createSubject.call(this, {
     date: '2013-01-01',
-    shortDate: momentFormat('date')
+    shortDate: format('date')
   });
 
   assert.equal(subject.get('shortDate'), '2013');
@@ -114,7 +138,7 @@ test('Observers trigger on date change', function(assert) {
   const subject = createSubject.call(this, {
     _format: 'MM/DD',
     format: alias('_format'),
-    shortDate: momentFormat('date', 'format'),
+    shortDate: format('date', 'format'),
     shortDateChanged: observer('shortDate', () => {
       observeFired = true;
     })

--- a/tests/unit/computeds/from-now-test.js
+++ b/tests/unit/computeds/from-now-test.js
@@ -2,9 +2,8 @@ import Ember from 'ember';
 import moment from 'moment';
 import getOwner from 'ember-getowner-polyfill';
 import { moduleFor, test } from 'ember-qunit';
-import momentFromNow from 'ember-moment/computeds/from-now';
-
-import hoursFromNow from '../../helpers/hours-from-now';
+import fromNow from 'ember-moment/computeds/from-now';
+import momentComputed from 'ember-moment/computeds/moment';
 
 moduleFor('ember-moment@computed:from-now', {
   setup() {
@@ -13,7 +12,7 @@ moduleFor('ember-moment@computed:from-now', {
   }
 });
 
-function createSubject(attrs={}) {
+function createSubject(attrs) {
   return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
     container: this.container,
     registry: this.registry
@@ -23,8 +22,8 @@ function createSubject(attrs={}) {
 test('get', function(assert) {
   assert.expect(1);
   const subject = createSubject.call(this, {
-    date: hoursFromNow(-1),
-    ago: momentFromNow('date')
+    date: moment().subtract(1, 'hour'),
+    ago: fromNow('date')
   });
   assert.equal(subject.get('ago'), 'an hour ago');
 });
@@ -33,12 +32,12 @@ test('get and set', function(assert) {
   assert.expect(2);
 
   const subject = createSubject.call(this, {
-    date: hoursFromNow(-1),
-    ago: momentFromNow('date')
+    date: moment().subtract(1, 'hour'),
+    ago: fromNow('date')
   });
 
   assert.equal(subject.get('ago'), 'an hour ago');
-  subject.set('date', hoursFromNow(-2));
+  subject.set('date', moment().subtract(2, 'hour'));
   assert.equal(subject.get('ago'), '2 hours ago');
 });
 
@@ -46,17 +45,17 @@ test('get literal', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    ago: momentFromNow(hoursFromNow(-1))
+    ago: fromNow(moment().subtract(1, 'hour'))
   });
 
   assert.equal(subject.get('ago'), 'an hour ago');
 });
 
-test('get literal without suffix', function(assert) {
+test('get literal without suffixx', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    ago: momentFromNow(hoursFromNow(-1), 'LLLL', true)
+    ago: fromNow(moment().subtract(1, 'hour'), 'LLLL', true)
   });
 
   assert.equal(subject.get('ago'), 'an hour');
@@ -66,7 +65,27 @@ test('get literal with suffix', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    ago: momentFromNow(hoursFromNow(-1), 'LLLL', false)
+    ago: fromNow(moment().subtract(1, 'hour'), 'LLLL', false)
+  });
+
+  assert.equal(subject.get('ago'), 'an hour ago');
+});
+
+test('composition with momentComputed get literal without suffix', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    ago: fromNow(momentComputed(moment().subtract(1, 'hour'), 'LLLL'), true)
+  });
+
+  assert.equal(subject.get('ago'), 'an hour');
+});
+
+test('composition with momentComputed get literal with suffix', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    ago: fromNow(momentComputed(moment().subtract(1, 'hour'), 'LLLL'), false)
   });
 
   assert.equal(subject.get('ago'), 'an hour ago');

--- a/tests/unit/computeds/moment-test.js
+++ b/tests/unit/computeds/moment-test.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+import moment from 'moment';
+import getOwner from 'ember-getowner-polyfill';
+import date from '../../helpers/date';
+import { moduleFor, test } from 'ember-qunit';
+import momentComputed from 'ember-moment/computeds/moment';
+
+moduleFor('ember-moment@computed:moment', {
+  setup() {
+    this.register('object:empty', Ember.Object.extend({}));
+    moment.locale('en');
+  }
+});
+
+function createSubject(attrs) {
+  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+    container: this.container,
+    registry: this.registry
+  })).create();
+}
+
+test('get', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    date: date(0),
+    computedDate: momentComputed('date')
+  });
+
+  assert.equal(subject.get('computedDate').format('MM/DD/YYYY'), '12/31/1969');
+});
+
+test('get and set', function(assert) {
+  assert.expect(2);
+
+  const subject = createSubject.call(this, {
+    date: date(0),
+    computedDate: momentComputed('date')
+  });
+
+  assert.equal(subject.get('computedDate').format('MM/DD/YYYY'), '12/31/1969');
+  subject.set('date', moment(date(0)).add(1, 'day'));
+  assert.equal(subject.get('computedDate').format('MM/DD/YYYY'), '01/01/1970');
+});
+
+test('get with literal', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    computedDate: momentComputed(date(0))
+  });
+
+  assert.equal(subject.get('computedDate').format('MM/DD/YYYY'), '12/31/1969');
+});

--- a/tests/unit/computeds/to-now-test.js
+++ b/tests/unit/computeds/to-now-test.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 import moment from 'moment';
 import getOwner from 'ember-getowner-polyfill';
 import { moduleFor, test } from 'ember-qunit';
-import momentToNow from 'ember-moment/computeds/to-now';
-import hoursFromNow from '../../helpers/hours-from-now';
+import toNow from 'ember-moment/computeds/to-now';
+import momentComputed from 'ember-moment/computeds/moment';
 
 moduleFor('ember-moment@computed:to-now', {
   setup() {
@@ -12,7 +12,7 @@ moduleFor('ember-moment@computed:to-now', {
   }
 });
 
-function createSubject(attrs={}) {
+function createSubject(attrs) {
   return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
     container: this.container,
     registry: this.registry
@@ -23,8 +23,8 @@ test('get', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    date: hoursFromNow(-1),
-    ago: momentToNow('date')
+    date: moment().subtract(1, 'hour'),
+    ago: toNow('date')
   });
 
   assert.equal(subject.get('ago'), 'in an hour');
@@ -34,12 +34,12 @@ test('get and set', function(assert) {
   assert.expect(2);
 
   const subject = createSubject.call(this, {
-    date: hoursFromNow(-1),
-    ago: momentToNow('date')
+    date: moment().subtract(1, 'hour'),
+    ago: toNow('date')
   });
 
   assert.equal(subject.get('ago'), 'in an hour');
-  subject.set('date', hoursFromNow(-2));
+  subject.set('date', moment().subtract(2, 'hour'));
   assert.equal(subject.get('ago'), 'in 2 hours');
 });
 
@@ -47,7 +47,7 @@ test('get literal', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    ago: momentToNow(hoursFromNow(-1))
+    ago: toNow(moment().subtract(1, 'hour'))
   });
 
   assert.equal(subject.get('ago'), 'in an hour');
@@ -57,7 +57,7 @@ test('get literal hide prefix', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    ago: momentToNow(hoursFromNow(-1), 'LLLL', true)
+    ago: toNow(moment().subtract(1, 'hour'), 'LLLL', true)
   });
 
   assert.equal(subject.get('ago'), 'an hour');
@@ -68,7 +68,27 @@ test('get literal with prefix', function(assert) {
   assert.expect(1);
 
   const subject = createSubject.call(this, {
-    ago: momentToNow(hoursFromNow(-1), 'LLLL', false)
+    ago: toNow(moment().subtract(1, 'hour'), 'LLLL', false)
+  });
+
+  assert.equal(subject.get('ago'), 'in an hour');
+});
+
+test('composition with momentComputed get literal without suffix', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    ago: toNow(momentComputed(moment().subtract(1, 'hour'), 'LLLL'), true)
+  });
+
+  assert.equal(subject.get('ago'), 'an hour');
+});
+
+test('composition with momentComputed get literal with suffix', function(assert) {
+  assert.expect(1);
+
+  const subject = createSubject.call(this, {
+    ago: toNow(momentComputed(moment().subtract(1, 'hour'), 'LLLL'), false)
   });
 
   assert.equal(subject.get('ago'), 'in an hour');

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
+import moment from 'moment';
 import { test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import moduleForHelper from '../../helpers/module-for-helper';
-import hoursFromNow from '../../helpers/hours-from-now';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
 moduleForHelper('moment-from-now',{
@@ -49,7 +49,7 @@ test('two args (date, inputFormat)', function(assert) {
 test('change date input and change is reflected by bound helper', function(assert) {
   assert.expect(2);
   const context = Ember.Object.create({
-    date: hoursFromNow(-1),
+    date: moment().subtract(1, 'hour'),
   });
 
   const view = this.createView({
@@ -62,7 +62,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.equal(view.$().text(), 'an hour ago');
 
   Ember.run(function () {
-    context.set('date', hoursFromNow(-2));
+    context.set('date', moment().subtract(2, 'hours'));
   });
 
   assert.equal(view.$().text(), '2 hours ago');
@@ -75,7 +75,7 @@ test('can inline a locale instead of using global locale', function(assert) {
   const view = this.createView({
     template: hbs`{{moment-from-now date locale='es'}}`,
     context: {
-      date: hoursFromNow(-1),
+      date: moment().subtract(1, 'hour'),
     }
   });
 

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
+import moment from 'moment';
 import { test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import moduleForHelper from '../../helpers/module-for-helper';
-import hoursFromNow from '../../helpers/hours-from-now';
 import { runAppend, runDestroy } from '../../helpers/run-append';
 
 moduleForHelper('moment-to-now', {
@@ -48,7 +48,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.expect(2);
 
   const context = Ember.Object.create({
-    date: hoursFromNow(-1),
+    date: moment().subtract(1, 'hour'),
   });
 
   const view = this.createView({
@@ -61,7 +61,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.equal(view.$().text(), 'in an hour');
 
   Ember.run(function () {
-    context.set('date', hoursFromNow(-2));
+    context.set('date', moment().subtract(2, 'hour'));
   });
 
   assert.equal(view.$().text(), 'in 2 hours');
@@ -74,7 +74,7 @@ test('can inline a locale instead of using global locale', function(assert) {
   const view = this.createView({
     template: hbs`{{moment-to-now date locale='es'}}`,
     context: {
-      date: hoursFromNow(-1),
+      date: moment().subtract(1, 'hour'),
     }
   });
 


### PR DESCRIPTION
* [x] Add computed property macros
  * [x] humanize
  * [x] locale
  * [x] tz
  * [x] moment
  * [x] calendar
* [x] Write tests
  * [x] Composition: momentComputed + toNow
  * [x] Composition: momentComputed + fromNow
  * [x] Composition: momentComputed + format
* [x] Document API changes
  * https://github.com/stefanpenner/ember-moment/wiki/Computed-Property-Macros

Fixes #135

This is API breaking due to the duration computed having to be split out into duration + humanize in order to have the ability to localize duration before humanizing through composition.

```
durationExample: humanize(locale(duration(10, 'hours'), 'fr')) // => 10 heures
```