### PR TITLE
Added support for moment().calendar() with moment-calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 {{moment-from-now date}}
 {{moment-to-now date}}
 {{moment-duration ms}}
+{{moment-calendar date}}
 ```
 
 ### Advanced Usage
@@ -32,6 +33,7 @@ It's advisable to run `ember g ember-moment` between upgrades as dependencies ma
 {{moment-from-now date}}
 {{moment-to-now date}}
 {{moment-duration number units}}
+{{moment-calendar date referenceDate}}
 ```
 
 ### Live Updating of Displayed Time

--- a/addon/helpers/moment-calendar.js
+++ b/addon/helpers/moment-calendar.js
@@ -1,0 +1,15 @@
+import moment from 'moment';
+
+import BaseHelper from './-base';
+
+export default BaseHelper.extend({
+  compute(params, { locale, timeZone }) {
+    if (!params || params && params.length > 2) {
+      throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
+    }
+
+    const [date, referenceTime] = params;
+
+    return this.morphMoment(moment(date), { locale, timeZone }).calendar(referenceTime);
+  }
+});

--- a/app/helpers/moment-calendar.js
+++ b/app/helpers/moment-calendar.js
@@ -1,0 +1,1 @@
+export { default, momentCalendar } from 'ember-moment/helpers/moment-calendar';

--- a/tests/unit/helpers/moment-calendar-test.js
+++ b/tests/unit/helpers/moment-calendar-test.js
@@ -1,0 +1,73 @@
+import hbs from 'htmlbars-inline-precompile';
+import { test } from 'ember-qunit';
+import date from '../../helpers/date';
+import { runAppend, runDestroy } from '../../helpers/run-append';
+import moduleForHelper from '../../helpers/module-for-helper';
+import moment from 'moment';
+
+moduleForHelper('moment-calendar', {
+  needs: ['service:moment'],
+});
+
+test('one arg (date)', function(assert) {
+  assert.expect(1);
+
+  const view = this.createView({
+    template: hbs`{{moment-calendar date}}`,
+    context: {
+      date: date(date(0)),
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), '12/31/1969');
+  runDestroy(view);
+});
+
+test('two args (date, referenceDate)', function(assert) {
+  assert.expect(1);
+
+  const view = this.createView({
+    template: hbs`{{moment-calendar date referenceDate timeZone='America/New_York'}}`,
+    context: {
+      date: moment('2013-01-01T02:30:26Z'),
+      referenceDate: moment('2013-01-01T12:00:00Z'),
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'Yesterday at 9:30 PM');
+  runDestroy(view);
+});
+
+test('with es locale', function(assert) {
+  assert.expect(1);
+
+  const view = this.createView({
+    template: hbs`{{moment-calendar date referenceDate locale="es" timeZone='America/New_York'}}`,
+    context: {
+      date: moment('2013-01-01T08:30:26Z'),
+      referenceDate: moment('2013-01-01T12:00:00Z'),
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'hoy a las 3:30');
+  runDestroy(view);
+});
+
+test('can inline timeZone (Sydney)', function(assert) {
+  assert.expect(1);
+
+  const view = this.createView({
+    template: hbs`{{moment-calendar date referenceDate timeZone='Australia/Sydney'}}`,
+    context: {
+      date: moment('2013-01-01T08:30:26Z'),
+      referenceDate: moment('2013-01-01T12:00:00Z'),
+    }
+  });
+
+  runAppend(view);
+  assert.equal(view.$().text(), 'Today at 7:30 PM', 'Australia is 11 hours ahead of UTC');
+  runDestroy(view);
+});


### PR DESCRIPTION
Adds support for the `moment().calendar()` — Calendar Time display, and addresses https://github.com/stefanpenner/ember-moment/issues/126

### Usage:

```hbs
{{moment-calendar aDate}}
{{moment-calendar aDate optionalReferenceDate locale="es" timeZone="Australia/Sydney"}}
```

Produces such outputs as:

- Today at 2:36 PM
- Yesterday at 2:36 PM
- Tomorrow at 2:36 PM
- Sunday at 2:36 PM
- Last Monday at 2:36 PM
- 7/10/2011

