### PR TITLE
Add a shortcut for isMoment

### DIFF
--- a/addon/services/moment.js
+++ b/addon/services/moment.js
@@ -41,6 +41,10 @@ export default Ember.Service.extend({
   changeTimeZone(timeZone) {
     this.set('timeZone', timeZone);
   },
+  
+  isMoment(obj) {
+    return moment.isMoment(obj);
+  },
 
   moment() {
     let time = moment(...arguments);


### PR DESCRIPTION
Unless I'm seeing it wrong it's harder than it should be to check if an object is a moment object.
The only way I'm able to check it is if I use moment from ``import moment from 'moment'`` in my code alongside importing the service.
I could just use the moment library directly without the service but the service already has the correct timezone.
This added method to the service would be very handy.