### PR TITLE
Support formatting to ISO 8601 instead of forcing default LLLL

### DIFF
--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -21,20 +21,20 @@ export default BaseHelper.extend({
       throw new TypeError('ember-moment: Invalid Number of arguments, expected at most 4');
     }
 
-    let format;
     const args = [];
+    const formatArgs = [];
 
     args.push(params[0]);
 
-    if (length === 1) {
-      format = this.get('moment.defaultFormat');
+    if (length === 1 && this.get('moment.defaultFormat')) {
+      formatArgs.push(this.get('moment.defaultFormat'));
     } else if (length === 2) {
-      format = params[1];
+      formatArgs.push(params[1]);
     } else if (length > 2) {
       args.push(params[2]);
-      format = params[1];
+      formatArgs.push(params[1]);
     }
 
-    return this.morphMoment(moment(...args), { locale, timeZone }).format(format);
+    return this.morphMoment(moment(...args), { locale, timeZone }).format(...formatArgs);
   })
 });

--- a/addon/services/moment.js
+++ b/addon/services/moment.js
@@ -9,14 +9,6 @@ export default Ember.Service.extend({
   locale: null,
   defaultFormat: null,
 
-  init() {
-    this._super(...arguments);
-
-    if (!this.get('defaultFormat')) {
-      this.set('defaultFormat', 'LLLL');
-    }
-  },
-
   timeZone: computed('_timeZone', {
     get() {
       return this.get('_timeZone');


### PR DESCRIPTION
* Only passes a format argument to `moment.format()` if one has been passed to the helper, or if `defaultFormat` has been set
* Removes initializer that automatically sets `defaultFormat` to `"LLLL"`

Fixes #161 