### PR TITLE
Now helper uses moment.now

### DIFF
--- a/addon/helpers/now.js
+++ b/addon/helpers/now.js
@@ -1,9 +1,10 @@
+import moment from 'moment';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
   compute() {
     this._super(...arguments);
 
-    return new Date();
+    return moment.now();
   }
 });

--- a/tests/unit/helpers/now-test.js
+++ b/tests/unit/helpers/now-test.js
@@ -1,0 +1,24 @@
+import moment from 'moment';
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+
+let originalNow;
+
+moduleForComponent('now', {
+  integration: true,
+  beforeEach() {
+    moment.locale('en');
+    originalNow = moment.now;
+  },
+  afterEach() {
+    moment.now = originalNow;
+  }
+});
+
+test('returns the result of moment.now', function(assert) {
+  assert.expect(1);
+
+  moment.now = () => moment('20111031');
+  this.render(hbs`{{moment-format (now) 'YYYYMMDD'}}`);
+  assert.equal(this.$().text(), '20111031');
+});


### PR DESCRIPTION
`now` helper now returns `moment.now` instead of `new Date()`