### PR TITLE
moment-calendar accepts format param and hash values

### DIFF
--- a/addon/computeds/calendar.js
+++ b/addon/computeds/calendar.js
@@ -1,13 +1,16 @@
+import Ember from 'ember';
 import moment from 'moment';
 
 import computedFactory from './-base';
 
-export default computedFactory(function calendarComputed(params) {
-  if (!params || params && params.length > 2) {
-    throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
+export default computedFactory(function calendarComputed(params, formatHash = {}) {
+  if (!params || params && params.length > 3) {
+    throw new TypeError('ember-moment: Invalid Number of arguments, at most 3');
   }
 
-  const [ date, referenceTime ] = params;
+  const [date, referenceTime, formats] = params;
+  const clone = Object.create(formatHash);
+  const mergedFormats = Ember.merge(clone, formats);
 
-  return moment(date).calendar(referenceTime);
+  return moment(date).calendar(referenceTime, mergedFormats);
 });

--- a/addon/helpers/moment-calendar.js
+++ b/addon/helpers/moment-calendar.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import moment from 'moment';
 
 import computeFn from '../utils/helper-compute';
@@ -6,15 +7,22 @@ import BaseHelper from './-base';
 export default BaseHelper.extend({
   globalAllowEmpty: false,
 
-  compute: computeFn(function (params, { locale, timeZone }) {
+  compute: computeFn(function (params, formatHash = {}) {
     this._super(...arguments);
 
-    if (!params || params && params.length > 2) {
-      throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');
+    if (!params || params && params.length > 3) {
+      throw new TypeError('ember-moment: Invalid Number of arguments, at most 3');
     }
 
-    const [date, referenceTime] = params;
+    const { locale, timeZone } = formatHash;
+    const [date, referenceTime, formats] = params;
+    const clone = Object.create(formatHash);
 
-    return this.morphMoment(moment(date), { locale, timeZone }).calendar(referenceTime);
+    delete clone.locale;
+    delete clone.timeZone;
+
+    const mergedFormats = Ember.merge(clone, formats);
+
+    return this.morphMoment(moment(date), { locale, timeZone }).calendar(referenceTime, mergedFormats);
   })
 });

--- a/tests/unit/helpers/moment-calendar-test.js
+++ b/tests/unit/helpers/moment-calendar-test.js
@@ -31,6 +31,57 @@ test('two args (date, referenceDate)', function(assert) {
   assert.equal(this.$().text(), 'Yesterday at 9:30 PM');
 });
 
+test('two args (date, referenceDate) with formats', function(assert) {
+  assert.expect(1);
+
+  this.setProperties({
+    date: moment('2013-01-01T02:30:26Z'),
+    referenceDate: moment('2013-01-01T12:00:00Z'),
+    formats:  {
+      sameDay: '[Today]',
+      nextDay: '[Tomorrow]',
+      nextWeek: 'dddd',
+      lastDay: '[Yesterday]',
+      lastWeek: '[Last] dddd',
+      sameElse: 'DD/MM/YYYY'
+    }
+  });
+
+  this.render(hbs`{{moment-calendar date referenceDate formats timeZone='America/New_York'}}`);
+  assert.equal(this.$().text(), 'Yesterday');
+});
+
+test('can pass individual formats', function(assert) {
+  assert.expect(1);
+
+  this.setProperties({
+    date: moment('2013-01-01T02:30:26Z'),
+    referenceDate: moment('2013-01-01T12:00:00Z'),
+    lastDay: '[Yesterday!]'
+  });
+
+  this.render(hbs`{{moment-calendar date referenceDate lastDay=lastDay timeZone='America/New_York'}}`);
+  assert.equal(this.$().text(), 'Yesterday!');
+});
+
+test('can use a combination of hash options and positional params', function(assert) {
+  assert.expect(2);
+
+  this.setProperties({
+    date: moment('2013-01-01T02:30:26Z'),
+    referenceDate: moment('2013-01-01T12:00:00Z'),
+    formats: {
+      sameDay: '[Today!]',
+      sameElse: 'DD/MM/YYYY'
+    }
+  });
+
+  this.render(hbs`{{moment-calendar date referenceDate formats lastDay='[YESTERDAY]' timeZone='America/New_York'}}`);
+
+  assert.equal(Object.keys(this.get('formats')).length, 2, 'formats object shape does not change');
+  assert.equal(this.$().text(), 'YESTERDAY');
+});
+
 test('with es locale', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Fixes #176

Adds the ability to pass format object or individual format properties as attributes.

```js
  this.setProperties({
    date: moment('2013-01-01T02:30:26Z'),
    referenceDate: moment('2013-01-01T12:00:00Z'),
    formats:  {
      sameDay: '[Today]',
      nextDay: '[Tomorrow]',
      nextWeek: 'dddd',
      lastDay: '[Yesterday]',
      lastWeek: '[Last] dddd',
      sameElse: 'DD/MM/YYYY'
    }
  });

  // full object
  this.render(hbs`{{moment-calendar date referenceDate formats}}`);

  // individual attrs
  this.render(hbs`{{moment-calendar date referenceDate sameDay='[Today]' nextDay='[Tomorrow]'}}`);
```