### PR TITLE
Removing ember-getowner-polyfill as a direct dep

### DIFF
--- a/addon/computeds/-base.js
+++ b/addon/computeds/-base.js
@@ -11,7 +11,6 @@ export default function computedFactory(fn) {
 
     computedArgs.push(function() {
       const params = args.map((arg) => getValue.call(this, arg));
-
       return fn.call(this, params);
     });
 

--- a/addon/computeds/format.js
+++ b/addon/computeds/format.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from '../utils/get-owner';
 
 import computedFactory from './-base';
 

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { observer, inject, Helper } = Ember;
+const { observer, inject, get, Helper } = Ember;
 const { bind:runBind } = Ember.run;
 
 export default Helper.extend({
@@ -12,7 +12,7 @@ export default Helper.extend({
   }),
 
   compute(value, { interval }) {
-    if (this.get('disableInterval')) { return; }
+    if (get(this, 'disableInterval')) { return; }
 
     this.clearTimer();
 
@@ -22,13 +22,13 @@ export default Helper.extend({
   },
 
   morphMoment(time, { locale, timeZone }) {
-    locale = locale || this.get('moment.locale');
+    locale = locale || get(this, 'moment.locale');
 
     if (locale) {
       time = time.locale(locale);
     }
 
-    timeZone = timeZone || this.get('moment.timeZone');
+    timeZone = timeZone || get(this, 'moment.timeZone');
 
     if (timeZone && time.tz) {
       time = time.tz(timeZone);

--- a/addon/utils/get-owner.js
+++ b/addon/utils/get-owner.js
@@ -1,0 +1,16 @@
+/* globals require */
+
+import Ember from 'ember';
+
+let getOwner = Ember.getOwner;
+
+if (!getOwner) {
+  try {
+    getOwner = require('ember-getowner-polyfill')['default'];
+  }
+  catch(e) {
+    Ember.Logger.warn('Ember.getOwner API unsupported.  To resolve this: `ember install ember-getowner-polyfill`');
+  }
+}
+
+export default getOwner;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-getowner-polyfill": "^1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
@@ -46,8 +47,7 @@
     "momentjs"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.1"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/controllers/test-subject.js
+++ b/tests/dummy/app/controllers/test-subject.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({});

--- a/tests/unit/computeds/calendar-test.js
+++ b/tests/unit/computeds/calendar-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-moment/utils/get-owner';
 import { moduleFor, test } from 'ember-qunit';
 import calendar from 'ember-moment/computeds/calendar';
 import tz from 'ember-moment/computeds/tz';

--- a/tests/unit/computeds/duration-test.js
+++ b/tests/unit/computeds/duration-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-moment/utils/get-owner';
 import { moduleFor, test } from 'ember-qunit';
 import duration from 'ember-moment/computeds/duration';
 import humanize from 'ember-moment/computeds/humanize';

--- a/tests/unit/computeds/format-test.js
+++ b/tests/unit/computeds/format-test.js
@@ -1,14 +1,13 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-moment/utils/get-owner';
 import { moduleFor, test } from 'ember-qunit';
 import format from 'ember-moment/computeds/format';
 import momentComputed from 'ember-moment/computeds/moment';
 import date from '../../helpers/date';
 
-moduleFor('ember-moment@computed:format', {
+moduleFor('controller:test-subject', {
   setup() {
-    this.register('object:empty', Ember.Object.extend({}));
     moment.locale('en');
   }
 });
@@ -17,12 +16,15 @@ const { observer, computed } = Ember;
 const { alias } = computed;
 
 function createSubject(attrs) {
-  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend({
+  const owner = getOwner(this);
+  const assign = Ember.assign || Ember.merge;
+
+  owner.resolveRegistration('controller:test-subject').reopen(assign({
     date: date(0),
-    shortDate: format('date', 'MM/DD'),
-    container: this.container,
-    registry: this.registry
-  }, attrs)).create();
+    shortDate: format('date', 'MM/DD')
+  }, attrs));
+
+  return this.subject();
 }
 
 test('get value as dependent key, format as dependent key', function(assert) {

--- a/tests/unit/computeds/from-now-test.js
+++ b/tests/unit/computeds/from-now-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-moment/utils/get-owner';
 import { moduleFor, test } from 'ember-qunit';
 import fromNow from 'ember-moment/computeds/from-now';
 import momentComputed from 'ember-moment/computeds/moment';

--- a/tests/unit/computeds/moment-test.js
+++ b/tests/unit/computeds/moment-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-moment/utils/get-owner';
 import date from '../../helpers/date';
 import { moduleFor, test } from 'ember-qunit';
 import momentComputed from 'ember-moment/computeds/moment';

--- a/tests/unit/computeds/to-now-test.js
+++ b/tests/unit/computeds/to-now-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import moment from 'moment';
-import getOwner from 'ember-getowner-polyfill';
+import getOwner from 'ember-moment/utils/get-owner';
 import { moduleFor, test } from 'ember-qunit';
 import toNow from 'ember-moment/computeds/to-now';
 import momentComputed from 'ember-moment/computeds/moment';


### PR DESCRIPTION
Related to a comment on #163

The other alternative is to send a PR to ember-getowner-polyfill to exclude itself if the target Ember version contains getOwner.

* [x] fix unit tests

/cc @stefanpenner @rwjblue 

Feel free to comment, I am happy to work on whatever alternative you propose even after this is merged.