### PR TITLE
converted moment-subtract and moment-add to use moment service

### DIFF
--- a/addon/helpers/moment-add.js
+++ b/addon/helpers/moment-add.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
-import moment from 'moment';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
+  moment: Ember.inject.service(),
+
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
+    const moment = this.get('moment');
     const { length } = params;
     const args = [];
     const additionArgs = [];
@@ -23,6 +25,6 @@ export default BaseHelper.extend({
       additionArgs.push(...params.slice(1));
     }
 
-    return this.morphMoment(moment(...args), { locale, timeZone }).add(...additionArgs, precision);
+    return this.morphMoment(moment.moment(...args), { locale, timeZone }).add(...additionArgs, precision);
   })
 });

--- a/addon/helpers/moment-subtract.js
+++ b/addon/helpers/moment-subtract.js
@@ -1,15 +1,16 @@
 import Ember from 'ember';
-import moment from 'moment';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
+  moment: Ember.inject.service(),
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
+    const moment = this.get('moment');
     const { length } = params;
     const args = [];
     const subtractionArgs = [];
@@ -23,6 +24,6 @@ export default BaseHelper.extend({
       subtractionArgs.push(...params.slice(1));
     }
 
-    return this.morphMoment(moment(...args), { locale, timeZone }).subtract(...subtractionArgs, precision);
+    return this.morphMoment(moment.moment(...args), { locale, timeZone }).subtract(...subtractionArgs, precision);
   })
 });

--- a/tests/unit/helpers/moment-add-test.js
+++ b/tests/unit/helpers/moment-add-test.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -11,9 +10,10 @@ moduleForComponent('moment-add',{
 
 test('one arg adds duration', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const duration = { days: 3 };
   this.set('duration', duration);
-  const expectedString = moment().add(duration).format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment().add(duration).format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-add duration}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -21,13 +21,14 @@ test('one arg adds duration', function(assert) {
 
 test('two args with number and string', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const number = 3;
   const precision = 'days';
   this.setProperties({
     number,
     precision
   });
-  const expectedString = moment().add(number, precision).format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment().add(number, precision).format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-add number precision}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -35,9 +36,10 @@ test('two args with number and string', function(assert) {
 
 test('two args with date and duration', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const duration = { days: 3 };
   this.set('duration', duration);
-  const expectedString = moment('2016-06-01').add(duration).format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment('2016-06-01').add(duration).format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-add '2016-06-01' duration}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -45,9 +47,10 @@ test('two args with date and duration', function(assert) {
 
 test('one arg with precision', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const number = 3;
   this.set('number', number);
-  const expectedString = moment().add(number, 'days').format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment().add(number, 'days').format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-add number precision='days'}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -55,9 +58,10 @@ test('one arg with precision', function(assert) {
 
 test('two args with precision', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const number = 3;
   this.set('number', number);
-  const expectedString = moment('2016-06-01').add(number, 'days').format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment('2016-06-01').add(number, 'days').format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-add '2016-06-01' number precision='days'}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));

--- a/tests/unit/helpers/moment-subtract-test.js
+++ b/tests/unit/helpers/moment-subtract-test.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -11,9 +10,10 @@ moduleForComponent('moment-subtract',{
 
 test('one arg subtracts duration', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const duration = { days: 3 };
   this.set('duration', duration);
-  const expectedString = moment().subtract(duration).format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment().subtract(duration).format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-subtract duration}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -21,13 +21,14 @@ test('one arg subtracts duration', function(assert) {
 
 test('two args with number and string', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const number = 3;
   const precision = 'days';
   this.setProperties({
     number,
     precision
   });
-  const expectedString = moment().subtract(number, precision).format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment().subtract(number, precision).format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-subtract number precision}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -35,9 +36,10 @@ test('two args with number and string', function(assert) {
 
 test('two args with date and duration', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const duration = { days: 3 };
   this.set('duration', duration);
-  const expectedString = moment('2016-06-01').subtract(duration).format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment('2016-06-01').subtract(duration).format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-subtract '2016-06-01' duration}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -45,9 +47,10 @@ test('two args with date and duration', function(assert) {
 
 test('one arg with precision', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const number = 3;
   this.set('number', number);
-  const expectedString = moment().subtract(number, 'days').format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment().subtract(number, 'days').format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-subtract number precision='days'}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));
@@ -55,9 +58,10 @@ test('one arg with precision', function(assert) {
 
 test('two args with precision', function(assert) {
   assert.expect(1);
+  const momentService = this.container.lookup('service:moment');
   const number = 3;
   this.set('number', number);
-  const expectedString = moment('2016-06-01').subtract(number, 'days').format('ddd MMM DD YYYY');
+  const expectedString = momentService.moment('2016-06-01').subtract(number, 'days').format('ddd MMM DD YYYY');
 
   this.render(hbs`{{moment-subtract '2016-06-01' number precision='days'}}`);
   assert.ok(this.$().text().match(new RegExp(expectedString)));


### PR DESCRIPTION
- Updated helpers moment-add and moment-subtract to use the moment service to persist the locale change on the service. 

- Added the moment service into each of the tests for both helpers.

Reference issue #196 