### PR TITLE
Add updateLocale to moment service

### DIFF
--- a/addon/services/moment.js
+++ b/addon/services/moment.js
@@ -1,12 +1,20 @@
 import Ember from 'ember';
 import moment from 'moment';
 
-const { computed, get, getProperties, set, Logger:logger } = Ember;
+const {
+  computed,
+  get,
+  getProperties,
+  set,
+  setProperties,
+  Logger:logger
+} = Ember;
 
 export default Ember.Service.extend(Ember.Evented, {
   _timeZone: null,
 
   locale: null,
+  localeOptions: {},
   defaultFormat: null,
 
   timeZone: computed('_timeZone', {
@@ -30,9 +38,16 @@ export default Ember.Service.extend(Ember.Evented, {
     this.changeLocale(locale);
   },
 
-  changeLocale(locale) {
-    set(this, 'locale', locale);
-    moment.locale(locale);
+  updateLocale(locale, localeOptions = {}) {
+    this.changeLocale(locale, localeOptions);
+  },
+
+  changeLocale(locale, localeOptions = {}) {
+    setProperties(this, {
+      locale,
+      localeOptions
+    });
+    moment.updateLocale(locale, localeOptions);
     this.trigger('localeChanged', locale);
   },
 

--- a/tests/integration/moment-test.js
+++ b/tests/integration/moment-test.js
@@ -94,3 +94,12 @@ test('moment can use the service locale (setLocale)', function(assert) {
 
   assert.equal(this.$().text(), 'mai 3, 2010');
 });
+
+test('moment can update service locale (updateLocale)', function(assert) {
+  assert.expect(2);
+
+  this.service.updateLocale('en', { week: { dow: 3 } });
+  assert.equal(moment().weekday(0).format('dddd'), 'Wednesday');
+  this.service.updateLocale('en', { week: { dow: 0 } });
+  assert.equal(moment().weekday(0).format('dddd'), 'Sunday');
+});


### PR DESCRIPTION
Adding updateLocale method to moment service

`moment.updateLocale()` - https://momentjs.com/docs/#/customization/

My use case required globally configuring moment weeks to start on a different weekday.  I'm not very familiar with the service/addon so feedback + suggestions are greatly appreciated!