### PR TITLE
Convert code to RFC #176 imports

### DIFF
--- a/addon/computeds/calendar.js
+++ b/addon/computeds/calendar.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { merge } from '@ember/polyfills';
 import moment from 'moment';
 
 import computedFactory from './-base';
@@ -10,7 +10,7 @@ export default computedFactory(function calendarComputed(params, formatHash = {}
 
   const [date, referenceTime, formats] = params;
   const clone = Object.create(formatHash);
-  const mergedFormats = Ember.merge(clone, formats);
+  const mergedFormats = merge(clone, formats);
 
   return moment(date).calendar(referenceTime, mergedFormats);
 });

--- a/addon/computeds/format.js
+++ b/addon/computeds/format.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { getOwner } from '@ember/application';
 import moment from 'moment';
 
 import computedFactory from './-base';
 
 const CONFIG_KEY = 'config:environment';
-const { get, getOwner } = Ember;
 
 export default computedFactory(function formatComputed([value, optionalFormat]) {
   if (!optionalFormat) {

--- a/addon/computeds/humanize.js
+++ b/addon/computeds/humanize.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+
 import computedFactory from './-base';
 
 export default computedFactory(function humanizeComputed([duration, suffixless]) {

--- a/addon/helpers/-base.js
+++ b/addon/helpers/-base.js
@@ -1,9 +1,10 @@
-import Ember from 'ember';
-
-const { observer, inject, get, Helper, run } = Ember;
+import { get, observer } from '@ember/object';
+import { run } from '@ember/runloop';
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
 
 export default Helper.extend({
-  moment: inject.service(),
+  moment: service(),
   disableInterval: false,
 
   localeOrTimeZoneChanged: observer('moment.locale', 'moment.timeZone', function() {

--- a/addon/helpers/is-after.js
+++ b/addon/helpers/is-after.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const comparisonArgs = [];

--- a/addon/helpers/is-before.js
+++ b/addon/helpers/is-before.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const comparisonArgs = [];

--- a/addon/helpers/is-between.js
+++ b/addon/helpers/is-between.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, inclusivity, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const _params = [].concat(params);
     const { length } = params;
 

--- a/addon/helpers/is-same-or-after.js
+++ b/addon/helpers/is-same-or-after.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const comparisonArgs = [];

--- a/addon/helpers/is-same-or-before.js
+++ b/addon/helpers/is-same-or-before.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const comparisonArgs = [];

--- a/addon/helpers/is-same.js
+++ b/addon/helpers/is-same.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const comparisonArgs = [];

--- a/addon/helpers/moment-add.js
+++ b/addon/helpers/moment-add.js
@@ -1,24 +1,26 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { typeOf } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const additionArgs = [];
 
     if (length === 1) {
       additionArgs.push(params[0]);
-    } else if (length === 2 && Ember.typeOf(params[0]) === 'number' && Ember.typeOf(params[1]) === 'string') {
+    } else if (length === 2 && typeOf(params[0]) === 'number' && typeOf(params[1]) === 'string') {
       additionArgs.push(...params);
     } else {
       args.push(params[0]);

--- a/addon/helpers/moment-calendar.js
+++ b/addon/helpers/moment-calendar.js
@@ -1,11 +1,13 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { merge } from '@ember/polyfills';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
-  
+  moment: service(),
+
   globalAllowEmpty: false,
 
   compute: computeFn(function (params, formatHash = {}) {
@@ -15,7 +17,7 @@ export default BaseHelper.extend({
       throw new TypeError('ember-moment: Invalid Number of arguments, at most 3');
     }
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { locale, timeZone } = formatHash;
     const [date, referenceTime, formats] = params;
     const clone = Object.create(formatHash);
@@ -23,7 +25,7 @@ export default BaseHelper.extend({
     delete clone.locale;
     delete clone.timeZone;
 
-    const mergedFormats = Ember.merge(clone, formats);
+    const mergedFormats = merge(clone, formats);
 
     return this.morphMoment(moment.moment(date), { locale, timeZone }).calendar(referenceTime, mergedFormats);
   })

--- a/addon/helpers/moment-diff.js
+++ b/addon/helpers/moment-diff.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
@@ -15,7 +16,7 @@ export default BaseHelper.extend({
       throw new TypeError('ember-moment: Invalid Number of arguments, must be 2');
     }
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const [dateA, dateB] = params;
 
     return this.morphMoment(moment.moment(dateB), { locale, timeZone }).diff(dateA, precision, float);

--- a/addon/helpers/moment-duration.js
+++ b/addon/helpers/moment-duration.js
@@ -1,16 +1,17 @@
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 import moment from 'moment';
-import Ember from 'ember';
 
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   disableInterval: true,
 
   compute(params, { locale, timeZone }) {
     this._super(...arguments);
-    const momentService = this.get('moment');
+    const momentService = get(this, 'moment');
 
     if (!params || params && params.length > 2) {
       throw new TypeError('ember-moment: Invalid Number of arguments, at most 2');

--- a/addon/helpers/moment-format.js
+++ b/addon/helpers/moment-format.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import { get, observer } from '@ember/object';
+import { isEmpty } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
-const { observer, isEmpty, get } = Ember;
-
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
 
   globalAllowEmpty: false,
 
@@ -17,7 +17,7 @@ export default BaseHelper.extend({
   compute: computeFn(function(params, { locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
 
     if (length > 3) {

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { hideSuffix, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
 
     return this.morphMoment(moment.moment(...params), { locale, timeZone }).fromNow(hideSuffix);
   })

--- a/addon/helpers/moment-from.js
+++ b/addon/helpers/moment-from.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function([ datetime, ...params ], { locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
 
     return this.morphMoment(moment.moment(datetime), { locale, timeZone }).from(...params);
   })

--- a/addon/helpers/moment-subtract.js
+++ b/addon/helpers/moment-subtract.js
@@ -1,23 +1,25 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { typeOf } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  moment: Ember.inject.service(),
+  moment: service(),
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { precision, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
     const { length } = params;
     const args = [];
     const subtractionArgs = [];
 
     if (length === 1) {
       subtractionArgs.push(params[0]);
-    } else if (length === 2 && Ember.typeOf(params[0]) === 'number' && Ember.typeOf(params[1]) === 'string') {
+    } else if (length === 2 && typeOf(params[0]) === 'number' && typeOf(params[1]) === 'string') {
       subtractionArgs.push(...params);
     } else {
       args.push(params[0]);

--- a/addon/helpers/moment-to-date.js
+++ b/addon/helpers/moment-to-date.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { hidePrefix, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
 
     return this.morphMoment(moment.moment(), { locale, timeZone }).to(...params, hidePrefix);
   })

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function(params, { hidePrefix, locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
 
     return this.morphMoment(moment.moment(...params), { locale, timeZone }).toNow(hidePrefix);
   })

--- a/addon/helpers/moment-to.js
+++ b/addon/helpers/moment-to.js
@@ -1,17 +1,18 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   globalAllowEmpty: false,
 
   compute: computeFn(function([ datetime, ...params ], { locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
 
     return this.morphMoment(moment.moment(datetime), { locale, timeZone }).to(...params);
   })

--- a/addon/helpers/moment.js
+++ b/addon/helpers/moment.js
@@ -1,13 +1,15 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   compute(params, { locale, timeZone }) {
     this._super(...arguments);
 
-    const moment = this.get('moment');
+    const moment = get(this, 'moment');
 
     return this.morphMoment(moment.moment(...params), { locale, timeZone });
   }

--- a/addon/helpers/now.js
+++ b/addon/helpers/now.js
@@ -1,14 +1,16 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 import moment from 'moment';
+
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   compute() {
     this._super(...arguments);
 
-    const momentService = this.get('moment');
+    const momentService = get(this, 'moment');
 
     return momentService.moment(moment.now());
   }

--- a/addon/helpers/unix.js
+++ b/addon/helpers/unix.js
@@ -1,14 +1,16 @@
-import Ember from 'ember';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 import moment from 'moment';
+
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-	moment: Ember.inject.service(),
+	moment: service(),
 
   compute([unixTimeStamp]) {
     this._super(...arguments);
-    
-    const momentService = this.get('moment');
+
+    const momentService = get(this, 'moment');
     return momentService.moment(moment.unix(unixTimeStamp));
   }
 });

--- a/addon/services/moment.js
+++ b/addon/services/moment.js
@@ -1,16 +1,13 @@
 import Ember from 'ember';
+import Service from '@ember/service';
+import Evented from '@ember/object/evented';
 import moment from 'moment';
+import { computed, get, set, getProperties, setProperties } from '@ember/object';
 
-const {
-  computed,
-  get,
-  getProperties,
-  set,
-  setProperties,
-  Logger:logger
-} = Ember;
+// question unresolved https://github.com/ember-cli/ember-rfc176-data/issues/12#issuecomment-318603308
+const { Logger: { warn }  } = Ember;
 
-export default Ember.Service.extend(Ember.Evented, {
+export default Service.extend(Evented, {
   _timeZone: null,
 
   locale: null,
@@ -24,7 +21,7 @@ export default Ember.Service.extend(Ember.Evented, {
 
     set(propertyKey, timeZone) {
       if (!moment.tz) {
-        logger.warn('[ember-moment] attempted to set timezone, but moment-timezone is not setup.');
+        warn('[ember-moment] attempted to set timezone, but moment-timezone is not setup.');
         return;
       }
 

--- a/addon/utils/helper-compute.js
+++ b/addon/utils/helper-compute.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
+import { isBlank } from '@ember/utils';
+import { get } from '@ember/object';
 
-const { isBlank, get, Logger: { warn } } = Ember;
+// question unresolved https://github.com/ember-cli/ember-rfc176-data/issues/12#issuecomment-318603308
+const { Logger: { warn } } = Ember;
 
 export default function(cb) {
   return function(params, hash) {

--- a/app/helpers/is-after.js
+++ b/app/helpers/is-after.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import IsAfterHelper from 'ember-moment/helpers/is-after';
 
+import config from '../config/environment';
+
 export default IsAfterHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/is-before.js
+++ b/app/helpers/is-before.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import IsBeforeHelper from 'ember-moment/helpers/is-before';
 
+import config from '../config/environment';
+
 export default IsBeforeHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/is-between.js
+++ b/app/helpers/is-between.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import IsBetweenHelper from 'ember-moment/helpers/is-between';
 
+import config from '../config/environment';
+
 export default IsBetweenHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/is-same-or-after.js
+++ b/app/helpers/is-same-or-after.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import IsSameOrAfterHelper from 'ember-moment/helpers/is-same-or-after';
 
+import config from '../config/environment';
+
 export default IsSameOrAfterHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/is-same-or-before.js
+++ b/app/helpers/is-same-or-before.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import IsSameOrBeforeHelper from 'ember-moment/helpers/is-same-or-before';
 
+import config from '../config/environment';
+
 export default IsSameOrBeforeHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/is-same.js
+++ b/app/helpers/is-same.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import IsSameHelper from 'ember-moment/helpers/is-same';
 
+import config from '../config/environment';
+
 export default IsSameHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-add.js
+++ b/app/helpers/moment-add.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import MomentAddHelper from 'ember-moment/helpers/moment-add';
 
+import config from '../config/environment';
+
 export default MomentAddHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-calendar.js
+++ b/app/helpers/moment-calendar.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import CalendarHelper from 'ember-moment/helpers/moment-calendar';
 
+import config from '../config/environment';
+
 export default CalendarHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-diff.js
+++ b/app/helpers/moment-diff.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import DiffHelper from 'ember-moment/helpers/moment-diff';
 
+import config from '../config/environment';
+
 export default DiffHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-format.js
+++ b/app/helpers/moment-format.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import FormatHelper from 'ember-moment/helpers/moment-format';
 
+import config from '../config/environment';
+
 export default FormatHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-from-now.js
+++ b/app/helpers/moment-from-now.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import FromNowHelper from 'ember-moment/helpers/moment-from-now';
 
+import config from '../config/environment';
+
 export default FromNowHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-from.js
+++ b/app/helpers/moment-from.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import FromHelper from 'ember-moment/helpers/moment-from';
 
+import config from '../config/environment';
+
 export default FromHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-subtract.js
+++ b/app/helpers/moment-subtract.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import MomentSubtractHelper from 'ember-moment/helpers/moment-subtract';
 
+import config from '../config/environment';
+
 export default MomentSubtractHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-to-date.js
+++ b/app/helpers/moment-to-date.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import ToDateHelper from 'ember-moment/helpers/moment-to-date';
 
+import config from '../config/environment';
+
 export default ToDateHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-to-now.js
+++ b/app/helpers/moment-to-now.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import ToNowHelper from 'ember-moment/helpers/moment-to-now';
 
+import config from '../config/environment';
+
 export default ToNowHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/helpers/moment-to.js
+++ b/app/helpers/moment-to.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import ToHelper from 'ember-moment/helpers/moment-to';
 
+import config from '../config/environment';
+
 export default ToHelper.extend({
-  globalAllowEmpty: !!Ember.get(config, 'moment.allowEmpty')
+  globalAllowEmpty: !!get(config, 'moment.allowEmpty')
 });

--- a/app/services/moment.js
+++ b/app/services/moment.js
@@ -1,7 +1,8 @@
-import Ember from 'ember';
-import config from '../config/environment';
+import { get } from '@ember/object';
 import MomentService from 'ember-moment/services/moment';
 
+import config from '../config/environment';
+
 export default MomentService.extend({
-  defaultFormat: Ember.get(config, 'moment.outputFormat')
+  defaultFormat: get(config, 'moment.outputFormat')
 });

--- a/tests/acceptance/smoke-test.js
+++ b/tests/acceptance/smoke-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
@@ -10,7 +10,7 @@ module('Acceptance: Smoke', {
   },
   afterEach() {
     if (application) {
-      Ember.run(application, 'destroy');
+      run(application, 'destroy');
     }
   }
 });

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,11 +1,11 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
 let App;
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,4 +1,6 @@
-import Ember from 'ember';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
 import duration from 'ember-moment/computeds/duration';
 import format from 'ember-moment/computeds/format';
 import fromNow from 'ember-moment/computeds/from-now';
@@ -6,14 +8,14 @@ import locale from 'ember-moment/computeds/locale';
 import humanize from 'ember-moment/computeds/humanize';
 import momentComputed from 'ember-moment/computeds/moment';
 
-export default Ember.Controller.extend({
-  moment: Ember.inject.service(),
+export default Controller.extend({
+  moment: service(),
   actions: {
     changeLocale(locale) {
-      this.get('moment').changeLocale(locale);
+      get(this, 'moment').changeLocale(locale);
     },
     changeDefaultFormat(defaultFormat) {
-      this.set('moment.defaultFormat', defaultFormat);
+      set(this, 'moment.defaultFormat', defaultFormat);
     }
   },
   emptyDate: null,

--- a/tests/dummy/app/controllers/smoke.js
+++ b/tests/dummy/app/controllers/smoke.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   currentTime: new Date(),
   usIndependenceDay: new Date(1776, 6, 4, 12, 0, 0)
 });

--- a/tests/dummy/app/controllers/test-subject.js
+++ b/tests/dummy/app/controllers/test-subject.js
@@ -1,3 +1,3 @@
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({});
+export default Controller.extend({});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+var Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,9 +1,11 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
-export default Ember.Route.extend({
-  moment: Ember.inject.service(),
+export default Route.extend({
+  moment: service(),
 
   beforeModel() {
-    this.get('moment').changeLocale('en');
+    get(this, 'moment').changeLocale('en');
   }
 });

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,17 +1,20 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { set } from '@ember/object';
+import { run } from '@ember/runloop';
 
-export default Ember.Route.extend({
-  moment: Ember.inject.service(),
+export default Route.extend({
+  moment: service(),
 
   beforeModel() {
-    this.set('moment.locale', 'en');
+    set(this, 'moment.locale', 'en');
   },
 
   setupController(controller, model) {
     this._super(controller, model);
 
     setInterval(function () {
-      Ember.run(function () {
+      run(function () {
         controller.set('date', new Date());
       });
     }, 1000);

--- a/tests/dummy/app/routes/smoke.js
+++ b/tests/dummy/app/routes/smoke.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 import moment from 'moment';
 
-export default Ember.Route.extend({
+export default Route.extend({
   setupController: function (controller, model) {
     moment.locale('en');
     return this._super(controller, model);

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
 import { module } from 'qunit';
-import Ember from 'ember';
+import { Promise } from 'rsvp';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/run-append.js
+++ b/tests/helpers/run-append.js
@@ -1,12 +1,12 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 function runAppend (view) {
-  Ember.run(view, 'appendTo', '#qunit-fixture');
+  run(view, 'appendTo', '#qunit-fixture');
 }
 
 function runDestroy (destroyed) {
   if (destroyed) {
-    Ember.run(destroyed, 'destroy');
+    run(destroyed, 'destroy');
   }
 }
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,14 +1,16 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
+
 import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/unit/computeds/calendar-test.js
+++ b/tests/unit/computeds/calendar-test.js
@@ -1,21 +1,21 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import EmberObject from '@ember/object';
+import { getOwner } from '@ember/application';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
 import calendar from 'ember-moment/computeds/calendar';
 import tz from 'ember-moment/computeds/tz';
 import locale from 'ember-moment/computeds/locale';
 
-const { getOwner } = Ember;
-
 moduleFor('ember-moment@computed:moment', {
   setup() {
-    this.register('object:empty', Ember.Object.extend({}));
+    this.register('object:empty', EmberObject.extend({}));
     moment.locale('en');
   }
 });
 
 function createSubject(attrs) {
-  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+  return getOwner(this).resolveRegistration('object:empty').extend($.extend(attrs, {
     container: this.container,
     registry: this.registry
   })).create();

--- a/tests/unit/computeds/duration-test.js
+++ b/tests/unit/computeds/duration-test.js
@@ -1,21 +1,21 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { getOwner } from '@ember/application';
+import $ from 'jquery';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
 import duration from 'ember-moment/computeds/duration';
 import humanize from 'ember-moment/computeds/humanize';
 import locale from 'ember-moment/computeds/locale';
 
-const { getOwner } = Ember;
-
 moduleFor('ember-moment@computed:duration', {
   setup() {
-    this.register('object:empty', Ember.Object.extend({}));
+    this.register('object:empty', EmberObject.extend({}));
     moment.locale('en');
   }
 });
 
 function createSubject(attrs) {
-  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+  return getOwner(this).resolveRegistration('object:empty').extend($.extend(attrs, {
     container: this.container,
     registry: this.registry
   })).create();

--- a/tests/unit/computeds/format-test.js
+++ b/tests/unit/computeds/format-test.js
@@ -1,11 +1,13 @@
-import Ember from 'ember';
+import { getOwner } from '@ember/application';
+import { merge } from '@ember/polyfills';
+import { observer } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
 import format from 'ember-moment/computeds/format';
 import momentComputed from 'ember-moment/computeds/moment';
-import date from '../../helpers/date';
 
-const { getOwner } = Ember;
+import date from '../../helpers/date';
 
 moduleFor('controller:test-subject', {
   setup() {
@@ -13,14 +15,10 @@ moduleFor('controller:test-subject', {
   }
 });
 
-const { observer, computed } = Ember;
-const { alias } = computed;
-
 function createSubject(attrs) {
   const owner = getOwner(this);
-  const assign = Ember.assign || Ember.merge;
 
-  owner.resolveRegistration('controller:test-subject').reopen(assign({
+  owner.resolveRegistration('controller:test-subject').reopen(merge({
     date: date(0),
     shortDate: format('date', 'MM/DD')
   }, attrs));

--- a/tests/unit/computeds/from-now-test.js
+++ b/tests/unit/computeds/from-now-test.js
@@ -1,20 +1,20 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { getOwner } from '@ember/application';
+import $ from 'jquery';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
 import fromNow from 'ember-moment/computeds/from-now';
 import momentComputed from 'ember-moment/computeds/moment';
 
-const { getOwner } = Ember;
-
 moduleFor('ember-moment@computed:from-now', {
   setup() {
-    this.register('object:empty', Ember.Object.extend({}));
+    this.register('object:empty', EmberObject.extend({}));
     moment.locale('en');
   }
 });
 
 function createSubject(attrs) {
-  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+  return getOwner(this).resolveRegistration('object:empty').extend($.extend(attrs, {
     container: this.container,
     registry: this.registry
   })).create();

--- a/tests/unit/computeds/moment-test.js
+++ b/tests/unit/computeds/moment-test.js
@@ -1,20 +1,20 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { getOwner } from '@ember/application';
+import $ from 'jquery';
 import moment from 'moment';
 import date from '../../helpers/date';
 import { moduleFor, test } from 'ember-qunit';
 import momentComputed from 'ember-moment/computeds/moment';
 
-const { getOwner } = Ember;
-
 moduleFor('ember-moment@computed:moment', {
   setup() {
-    this.register('object:empty', Ember.Object.extend({}));
+    this.register('object:empty', EmberObject.extend({}));
     moment.locale('en');
   }
 });
 
 function createSubject(attrs) {
-  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+  return getOwner(this).resolveRegistration('object:empty').extend($.extend(attrs, {
     container: this.container,
     registry: this.registry
   })).create();

--- a/tests/unit/computeds/to-now-test.js
+++ b/tests/unit/computeds/to-now-test.js
@@ -1,20 +1,20 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { getOwner } from '@ember/application';
+import $ from 'jquery';
 import moment from 'moment';
 import { moduleFor, test } from 'ember-qunit';
 import toNow from 'ember-moment/computeds/to-now';
 import momentComputed from 'ember-moment/computeds/moment';
 
-const { getOwner } = Ember;
-
 moduleFor('ember-moment@computed:to-now', {
   setup() {
-    this.register('object:empty', Ember.Object.extend({}));
+    this.register('object:empty', EmberObject.extend({}));
     moment.locale('en');
   }
 });
 
 function createSubject(attrs) {
-  return getOwner(this).resolveRegistration('object:empty').extend(Ember.$.extend(attrs, {
+  return getOwner(this).resolveRegistration('object:empty').extend($.extend(attrs, {
     container: this.container,
     registry: this.registry
   })).create();

--- a/tests/unit/helpers/is-after-test.js
+++ b/tests/unit/helpers/is-after-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -12,7 +12,7 @@ test('one arg (comparisonDate)', function(assert) {
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeDaysFromNow = today.add(3, 'days');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeDaysFromNow
   });
   this.set('context', context);
@@ -27,7 +27,7 @@ test('one arg with precision (comparisonDate, precision)', function(assert) {
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeYearsAgo = today.subtract(3, 'years');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeYearsAgo
   });
   this.set('context', context);

--- a/tests/unit/helpers/is-between-test.js
+++ b/tests/unit/helpers/is-between-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -12,7 +12,7 @@ test('two args (comparisonDate1, comparisonDate2)', function(assert) {
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeDaysFromNow = today.add(3, 'days');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeDaysFromNow
   });
   this.set('context', context);
@@ -27,7 +27,7 @@ test('two args (comparisonDate1, comparisonDate2, precision)', function(assert) 
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeYearsFromNow = today.add(3, 'years');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeYearsFromNow
   });
   this.set('context', context);
@@ -42,7 +42,7 @@ test('two args (comparisonDate1, comparisonDate2, precision, inclusivity)', func
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeDaysFromNow = today.add(3, 'days');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeDaysFromNow
   });
   this.set('context', context);

--- a/tests/unit/helpers/is-same-or-after-test.js
+++ b/tests/unit/helpers/is-same-or-after-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -12,7 +12,7 @@ test('one arg (comparisonDate)', function(assert) {
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeDaysFromNow = today.add(3, 'days');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeDaysFromNow
   });
   this.set('context', context);
@@ -27,7 +27,7 @@ test('one arg with precision (comparisonDate, precision)', function(assert) {
   const momentService = this.container.lookup('service:moment');
   const today = momentService.moment();
   const threeYearsAgo = today.subtract(3, 'years');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeYearsAgo
   });
   this.set('context', context);

--- a/tests/unit/helpers/is-same-test.js
+++ b/tests/unit/helpers/is-same-test.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -18,7 +18,7 @@ test('one arg with precision (comparisonDate, precision)', function(assert) {
 
   const today = new Date();
   const date = `${today.getFullYear()}-10-19`;
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: date
   });
   this.set('context', context);

--- a/tests/unit/helpers/moment-format-test.js
+++ b/tests/unit/helpers/moment-format-test.js
@@ -1,4 +1,6 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
+import { helper } from '@ember/component/helper';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -29,9 +31,9 @@ test('updating default format recomputes moment-format', function(assert) {
 
   assert.equal(this.$().text(), 'Wednesday, December 31, 1969 7:00 PM');
 
-  Ember.run(() => {
+  run(() => {
     service.set('defaultFormat', 'DD.MM.YYYY');
-    Ember.run.scheduleOnce('afterRender', () => {
+    run.scheduleOnce('afterRender', () => {
       assert.equal(this.$().text(), '31.12.1969');
     });
   });
@@ -65,7 +67,7 @@ test('three args (date, outputFormat, inputFormat)', function(assert) {
 test('change date input and change is reflected by bound helper', function(assert) {
   assert.expect(2);
 
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: date(0)
   });
 
@@ -74,7 +76,7 @@ test('change date input and change is reflected by bound helper', function(asser
   this.render(hbs`{{moment-format context.date}}`);
   assert.equal(this.$().text(), 'Wednesday, December 31, 1969 7:00 PM');
 
-  Ember.run(function () {
+  run(function () {
     context.set('date', date(60*60*24));
   });
 
@@ -117,7 +119,7 @@ test('can be called with null when allow-empty is set to true', function(assert)
 test('can be called using subexpression', function(assert) {
   assert.expect(1);
 
-  this.registry.register('helper:get-format', Ember.Helper.helper(function() {
+  this.registry.register('helper:get-format', helper(function() {
     return 'L';
   }));
 

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -15,7 +16,7 @@ test('one arg (date)', function(assert) {
   const threeDaysAgo = new Date();
   threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: threeDaysAgo
   });
 
@@ -44,7 +45,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.expect(2);
 
   const momentService = this.container.lookup('service:moment');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: momentService.moment().subtract(1, 'hour'),
   });
 
@@ -53,7 +54,7 @@ test('change date input and change is reflected by bound helper', function(asser
   this.render(hbs`{{moment-from-now context.date}}`);
   assert.equal(this.$().text(), 'an hour ago');
 
-  Ember.run(function () {
+  run(function () {
     context.set('date', momentService.moment().subtract(2, 'hours'));
   });
 

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -38,7 +39,7 @@ test('change date input and change is reflected by bound helper', function(asser
   assert.expect(2);
 
   const momentService = this.container.lookup('service:moment');
-  const context = Ember.Object.create({
+  const context = EmberObject.create({
     date: momentService.moment().subtract(1, 'hour'),
   });
 
@@ -46,7 +47,7 @@ test('change date input and change is reflected by bound helper', function(asser
   this.render(hbs`{{moment-to-now context.date}}`);
   assert.equal(this.$().text(), 'in an hour');
 
-  Ember.run(function () {
+  run(function () {
     context.set('date', momentService.moment().subtract(2, 'hour'));
   });
 

--- a/tests/unit/helpers/now-test.js
+++ b/tests/unit/helpers/now-test.js
@@ -1,4 +1,3 @@
-/* globals self */
 import moment from 'moment';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';


### PR DESCRIPTION
[RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-javascript-module-api.md) introduces new modular imports so that you can import only the parts of Ember that you require inside that file.