### PR TITLE
Deprecate hide(Suff/Pref)ix for hideAffix + update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@
 [moment.js](http://momentjs.com) template helpers and computed property macros for Ember
 
 ## Requirements
-* Ember >= 1.13.0
-* Ember CLI
+* ember-cli ~= 2.18.1
 
 ## Installing
 
-* ember-cli >= 0.2.3 `ember install ember-moment`
+* `ember install ember-moment`
 
 ## Upgrading
 
@@ -68,85 +67,50 @@ Formats a `<date>` to an optional `outputFormat` from an optional `inputFormat`.
 {{moment-format '12-1995-25' 'MM/DD/YYYY' 'MM-YYYY-DD'}} {{!-- 12/25/1995 --}}
 ```
 
-### moment-from-now
+### moment-from / moment-from-now
 
 ```hbs
-{{moment-from-now <date> [hideSuffix=false]}}
-```
-
-| Parameters | Values |
-| ---------- | ------ |
-| `<date>` | Any value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/) by `moment` (a date `String` or a `Moment` or a `Date`...) |
-| `hideSuffix` | An optional `Boolean` to hide the relative suffix or not |
-
-Returns the time between `<date>` and now relative to now. See [`momentjs#fromNow`](https://momentjs.com/docs/#/displaying/fromnow/).
-
-**Examples**
-
-```hbs
-{{!-- in January 2018 at time of writing --}}
-{{moment-from-now '2995-12-25'}} {{!-- in 978 years --}}
-{{moment-from-now '1995-12-25' hideSuffix=true}} {{!-- 22 years --}}
-```
-
-### moment-from
-
-```hbs
-{{moment-from <dateA> [<dateB>]}}
+{{moment-from <dateA> [<dateB>] [hideAffix=false]}}
+{{moment-from-now <dateA> [hideAffix=false]}}
 ```
 
 | Parameters | Values |
 | ---------- | ------ |
 | `<dateA>` | Any value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/) by `moment` (a date `String` or a `Moment` or a `Date`...) |
 | `<dateB>` | An optional value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/) by `moment` (a date `String` or a `Moment` or a `Date`...), defaults to now |
+| `hideAffix` | An optional `Boolean` to hide the relative prefix/suffix or not.  |
+| `hideSuffix` | **Deprecated** An optional `Boolean` to hide the relative suffix or not. It was only available for `moment-from` and will be removed in `8.0.0`|
 
 Returns the time between `<dateA>` and `<dateB>` relative to `<dateB>`. See [`momentjs#from`](https://momentjs.com/docs/#/displaying/from/).
 
-*Note that `moment-from-now` is just a special case of this helper with the additional ability to hide the suffix.* 
+*Note that `moment-from-now` is just a more verbose `moment-from` without `dateB`. You don't need to use it anymore.* 
 
 **Examples**
 
 ```hbs
 {{!-- in January 2018 at time of writing --}}
 {{moment-from '2995-12-25'}} {{!-- in 978 years --}}
-{{moment-from '1995-12-25' '2995-12-25'}} {{!-- 1000 years ago --}}
+{{moment-from-now '2995-12-25'}} {{!-- in 978 years --}}
+{{moment-from '1995-12-25' '2995-12-25' hideAffix=true}} {{!-- 1000 years --}}
 ```
 
-### moment-to-now
+### moment-to / moment-to-now
 
 ```hbs
-{{moment-to-now <date> [hideSuffix=false]}}
-```
-
-| Parameters | Values |
-| ---------- | ------ |
-| `<date>` | Any value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/) by `moment` (a date `String` or a `Moment` or a `Date`...) |
-| `hideSuffix` | An optional `Boolean` to hide the relative suffix or not |
-
-Returns the time between `<date>` and now relative to `<date>`. See [`momentjs#toNow`](https://momentjs.com/docs/#/displaying/tonow/).
-
-**Examples**
-
-```hbs
-{{!-- in January 2018 at time of writing --}}
-{{moment-to-now '2995-12-25'}} {{!-- 978 years ago --}}
-{{moment-to-now '1995-12-25' hideSuffix=true}} {{!-- in 22 years --}}
-```
-
-### moment-to
-
-```hbs
-{{moment-to <dateA> [<dateB>]}}
+{{moment-to <dateA> [<dateB>] [hideAffix=false]}}
+{{moment-to-now <dateA> [hideAffix=false]}}
 ```
 
 | Parameters | Values |
 | ---------- | ------ |
 | `<dateA>` | Any value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/) by `moment` (a date `String` or a `Moment` or a `Date`...) |
 | `<dateB>` | An optional value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/) by `moment` (a date `String` or a `Moment` or a `Date`...), defaults to now |
+| `hideAffix` | An optional `Boolean` to hide the relative prefix/suffix or not.  |
+| `hidePrefix` | **Deprecated** An optional `Boolean` to hide the relative prefix or not. It was only available for `moment-to` and will be removed in `8.0.0` |
 
 Returns the time between `<dateA>` and `<dateB>` relative to `<dateA>`. See [`momentjs#to`](https://momentjs.com/docs/#/displaying/to/).
 
-*Note that `moment-to-now` is just a special case of this helper with the additional ability to hide the suffix.* 
+*Note that `moment-to-now` is just a more verbose `moment-to` without `dateB`. You don't need to use it anymore.* 
 
 **Examples**
 
@@ -154,6 +118,7 @@ Returns the time between `<dateA>` and `<dateB>` relative to `<dateA>`. See [`mo
 {{!-- in January 2018 at time of writing --}}
 {{moment-to '2995-12-25'}} {{!-- 978 years ago --}}
 {{moment-to '1995-12-25' '2995-12-25'}} {{!-- in 1000 years --}}
+{{moment-to-now '1995-12-25' hideAffix=true}} {{!-- 22 years --}}
 ```
 
 ### moment-duration
@@ -220,7 +185,7 @@ Returns the difference in `precision` units between `<dateA>` and `<dateB>` with
 {{moment-diff '2018-01-25' '2018-01-26' precision='years' float=true}} {{!-- 0.0026881720430107525 --}}
 ```
 
-### is-before/after/same/same-or-before/same-or-after
+### is-before / is-after / is-same / is-same-or-before / is-same-or-after
 
 ```hbs
 {{is-before <dateA> [<dateB>] [precision='milliseconds']}}

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -1,14 +1,21 @@
+import { deprecate } from '@ember/application/deprecations';
 import { get } from '@ember/object';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  compute: computeFn(function(params, { hideSuffix, locale, timeZone }) {
+  compute: computeFn(function(params, { hideSuffix, hideAffix, locale, timeZone }) {
+    deprecate(
+      'hideSuffix is deprecated in favour of hideAffix',
+      hideSuffix === undefined,  // display if this is false
+      {id: 'ember-moment.addon.helpers.moment-from-now', until: '8.0.0'}
+    );
+
     this._super(...arguments);
 
     const moment = get(this, 'moment');
-
-    return this.morphMoment(moment.moment(...params), { locale, timeZone }).fromNow(hideSuffix);
+    const hide = hideSuffix || hideAffix;
+    return this.morphMoment(moment.moment(...params), { locale, timeZone }).fromNow(hide);
   })
 });

--- a/addon/helpers/moment-from.js
+++ b/addon/helpers/moment-from.js
@@ -4,11 +4,11 @@ import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  compute: computeFn(function([ datetime, ...params ], { locale, timeZone }) {
+  compute: computeFn(function([ datetime, ...params ], { hideAffix, locale, timeZone }) {
     this._super(...arguments);
 
     const moment = get(this, 'moment');
 
-    return this.morphMoment(moment.moment(datetime), { locale, timeZone }).from(...params);
+    return this.morphMoment(moment.moment(datetime), { locale, timeZone }).from(...params, hideAffix);
   })
 });

--- a/addon/helpers/moment-to-now.js
+++ b/addon/helpers/moment-to-now.js
@@ -1,14 +1,21 @@
+import { deprecate } from '@ember/application/deprecations';
 import { get } from '@ember/object';
 
 import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  compute: computeFn(function(params, { hidePrefix, locale, timeZone }) {
+  compute: computeFn(function(params, { hidePrefix, hideAffix, locale, timeZone }) {
+    deprecate(
+      'hidePrefix is deprecated in favour of hideAffix',
+      hidePrefix === undefined,  // display if this is false
+      {id: 'ember-moment.addon.helpers.moment-to-now', until: '8.0.0'}
+    );
+
     this._super(...arguments);
 
     const moment = get(this, 'moment');
-
-    return this.morphMoment(moment.moment(...params), { locale, timeZone }).toNow(hidePrefix);
+    const hide = hidePrefix || hideAffix;
+    return this.morphMoment(moment.moment(...params), { locale, timeZone }).toNow(hide);
   })
 });

--- a/addon/helpers/moment-to.js
+++ b/addon/helpers/moment-to.js
@@ -4,11 +4,11 @@ import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  compute: computeFn(function([ datetime, ...params ], { locale, timeZone }) {
+  compute: computeFn(function([ datetime, ...params ], { hideAffix, locale, timeZone }) {
     this._super(...arguments);
 
     const moment = get(this, 'moment');
 
-    return this.morphMoment(moment.moment(datetime), { locale, timeZone }).to(...params);
+    return this.morphMoment(moment.moment(datetime), { locale, timeZone }).to(...params, hideAffix);
   })
 });

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -26,6 +26,20 @@ test('one arg (date)', function(assert) {
   assert.equal(this.$().text(), '3 days ago');
 });
 
+test('one arg (dateA, hideAffix=boolean)', function(assert) {
+  assert.expect(2);
+
+  const momentService = this.container.lookup('service:moment');
+  this.setProperties({
+    dateA: momentService.moment().add(3, 'day'),
+  });
+
+  this.render(hbs`{{moment-to-now dateA hideAffix=true}}`);
+  assert.equal(this.$().text(), '3 days');
+  this.render(hbs`{{moment-to-now dateA hideAffix=false}}`);
+  assert.equal(this.$().text(), '3 days ago');
+});
+
 test('two args (date, inputFormat)', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/helpers/moment-from-test.js
+++ b/tests/unit/helpers/moment-from-test.js
@@ -32,6 +32,21 @@ test('two args (dateA, dateB)', function(assert) {
   assert.equal(this.$().text(), 'in 3 days');
 });
 
+test('two args (dateA, dateB, hideAffix=boolean)', function(assert) {
+  assert.expect(2);
+
+  const momentService = this.container.lookup('service:moment');
+  this.setProperties({
+    dateA: new Date(),
+    dateB: momentService.moment().add(3, 'day')
+  });
+
+  this.render(hbs`{{moment-from dateB dateA hideAffix=true}}`);
+  assert.equal(this.$().text(), '3 days');
+  this.render(hbs`{{moment-from dateB dateA hideAffix=false}}`);
+  assert.equal(this.$().text(), 'in 3 days');
+});
+
 test('three args (dateA, dateB, boolean)', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/helpers/moment-to-now-test.js
+++ b/tests/unit/helpers/moment-to-now-test.js
@@ -12,23 +12,37 @@ moduleForComponent('moment-to-now',{
 
 test('one arg (date)', function(assert) {
   assert.expect(1);
-  const addThreeDays = new Date();
-  addThreeDays.setDate(addThreeDays.getDate() - 3);
 
-  this.set('date', addThreeDays);
+  const momentService = this.container.lookup('service:moment');
+  this.setProperties({
+    dateA: momentService.moment().subtract(3, 'day'),
+  });
 
-  this.render(hbs`{{moment-to-now date}}`);
+  this.render(hbs`{{moment-to-now dateA}}`);
+  assert.equal(this.$().text(), 'in 3 days');
+});
+
+test('one arg (date, hideAffix=boolean)', function(assert) {
+  assert.expect(2);
+
+  const momentService = this.container.lookup('service:moment');
+  this.setProperties({
+    date: momentService.moment().subtract(3, 'day'),
+  });
+
+  this.render(hbs`{{moment-to-now date hideAffix=true}}`);
+  assert.equal(this.$().text(), '3 days');
+  this.render(hbs`{{moment-to-now date hideAffix=false}}`);
   assert.equal(this.$().text(), 'in 3 days');
 });
 
 test('two args (date, inputFormat)', function(assert) {
   assert.expect(1);
-  const addThreeDays = new Date();
-  addThreeDays.setDate(addThreeDays.getDate() - 3);
 
+  const momentService = this.container.lookup('service:moment');
   this.setProperties({
     format: 'LLLL',
-    date: addThreeDays
+    date: momentService.moment().subtract(3, 'day'),
   });
 
   this.render(hbs`{{moment-to-now date format}}`);

--- a/tests/unit/helpers/moment-to-test.js
+++ b/tests/unit/helpers/moment-to-test.js
@@ -31,6 +31,21 @@ test('two args (dateA, dateB)', function(assert) {
   assert.equal(this.$().text(), 'in 3 days');
 });
 
+test('two args (dateA, dateB, hideAffix=boolean)', function(assert) {
+  assert.expect(2);
+
+  const momentService = this.container.lookup('service:moment');
+  this.setProperties({
+    dateA: new Date(),
+    dateB: momentService.moment().add(3, 'day')
+  });
+
+  this.render(hbs`{{moment-to dateA dateB hideAffix=true}}`);
+  assert.equal(this.$().text(), '3 days');
+  this.render(hbs`{{moment-to dateA dateB hideAffix=false}}`);
+  assert.equal(this.$().text(), 'in 3 days');
+});
+
 test('three args (dateA, dateB, boolean)', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
This is addressing point number 2 from previous pull request.

- `moment-to` and `moment-from` helpers can now also hide affix.
- tests have been added.
- I changed the requirements in the README to reflect `package.json` - is this appropriate? (why is `ember-cli` a devDependency and not a dependency?)
- Simplified the README
- Technically `moment-from-now` and `moment-to-now` helpers are not needed anymore. Should we deprecate them as well (point number 3)?

thanks!