### PR TITLE
add utc helper and computed property macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ Returns a Moment.
 {{moment '12-25-1995' 'MM-DD-YYYY'}} {{!-- Mon Dec 25 1995 00:00:00 GMT-0500 --}}
 ```
 
+### utc
+
+```hbs
+{{utc <date>}}
+{{utc}}
+```
+
+
+| Parameters | Values |
+| ---------- | ------ |
+| `<date>` | Any value(s) [interpretable as a date/time](https://momentjs.com/docs/#/parsing/utc) by `moment` (a date `String` or a `Moment` or a `Date`...)|
+
+Returns a Moment with [utc mode](http://momentjs.com/docs/#/parsing/utc/) set.
+
+**Example**
+
+```hbs
+{{utc '2001-10-31T08:24:56'}} {{!-- Wed Oct 31 2001 08:24:56 GMT+0000 --}}
+{{utc}} {{!-- current time utc, like Mon Feb 12 2018 20:33:08 GMT+0000 --}}
+{{utc (moment '2018-01-01T00:00:00+01:00' 'YYYY-MM-DD HH:mm:ssZ')}}  {{!-- Sun Dec 31 2017 23:00:00 GMT+0000 --}}
+```
+
+
 ### moment-format
 
 ```hbs
@@ -57,7 +80,7 @@ Returns a Moment.
 | `outputFormat` | An optional date/time `String` [output format](https://momentjs.com/docs/#/displaying/format/), defaults to `moment.defaultFormat` which you must [explicitly define](#global-default-output-format) |
 | `<inputFormat>` | An optional date/time `String` [input format](https://momentjs.com/docs/#/parsing/string) |
 
-Formats a `<date>` to an optional `outputFormat` from an optional `inputFormat`. If the `inputFormat` is not provided, the date `String` is parsed on a best effort basis. If the `outputFormat` is not given the global `moment.defaultFormat` is used. Typically, `outputFormat` and `inputFormat` are given. See [`momentjs#format`](https://momentjs.com/docs/#/displaying/format/). 
+Formats a `<date>` to an optional `outputFormat` from an optional `inputFormat`. If the `inputFormat` is not provided, the date `String` is parsed on a best effort basis. If the `outputFormat` is not given the global `moment.defaultFormat` is used. Typically, `outputFormat` and `inputFormat` are given. See [`momentjs#format`](https://momentjs.com/docs/#/displaying/format/).
 
 *NOTE: for all other helpers, the input format string is the second argument.*
 
@@ -83,7 +106,7 @@ Formats a `<date>` to an optional `outputFormat` from an optional `inputFormat`.
 
 Returns the time between `<dateA>` and `<dateB>` relative to `<dateB>`. See [`momentjs#from`](https://momentjs.com/docs/#/displaying/from/).
 
-*Note that `moment-from-now` is just a more verbose `moment-from` without `dateB`. You don't need to use it anymore.* 
+*Note that `moment-from-now` is just a more verbose `moment-from` without `dateB`. You don't need to use it anymore.*
 
 **Examples**
 
@@ -110,7 +133,7 @@ Returns the time between `<dateA>` and `<dateB>` relative to `<dateB>`. See [`mo
 
 Returns the time between `<dateA>` and `<dateB>` relative to `<dateA>`. See [`momentjs#to`](https://momentjs.com/docs/#/displaying/to/).
 
-*Note that `moment-to-now` is just a more verbose `moment-to` without `dateB`. You don't need to use it anymore.* 
+*Note that `moment-to-now` is just a more verbose `moment-to` without `dateB`. You don't need to use it anymore.*
 
 **Examples**
 
@@ -191,7 +214,7 @@ Returns the difference in `precision` units between `<dateA>` and `<dateB>` with
 {{is-before <dateA> [<dateB>] [precision='milliseconds']}}
 {{is-after <dateA> [<dateB>] [precision='milliseconds']}}
 {{is-same <dateA> [<dateB>] [precision='milliseconds']}}
-{{is-same-or-before <dateA> [<dateB>] [precision='milliseconds']}} 
+{{is-same-or-before <dateA> [<dateB>] [precision='milliseconds']}}
 {{is-same-or-after <dateA> [<dateB>] [precision='milliseconds']}}
 ```
 

--- a/addon/computeds/utc.js
+++ b/addon/computeds/utc.js
@@ -1,0 +1,7 @@
+import moment from 'moment';
+
+import computedFactory from './-base';
+
+export default computedFactory(function utcComputed(params) {
+  return moment.utc(...params);
+});

--- a/addon/helpers/utc.js
+++ b/addon/helpers/utc.js
@@ -1,0 +1,11 @@
+import { get } from '@ember/object';
+import moment from 'moment';
+import BaseHelper from './-base';
+
+export default BaseHelper.extend({
+  compute([utcTime, format]) {
+    this._super(...arguments);
+
+    return get(this, 'moment').utc(moment.utc(utcTime, format));
+  }
+});

--- a/addon/services/moment.js
+++ b/addon/services/moment.js
@@ -81,5 +81,17 @@ export default Service.extend(Evented, {
     }
 
     return momentObj;
+  },
+
+  utc() {
+      let momentObj = moment.utc(...arguments);
+
+      let { locale } = getProperties(this, 'locale');
+
+      if (locale && momentObj.locale) {
+        momentObj = momentObj.locale(locale);
+      }
+
+      return momentObj;
   }
 });

--- a/app/helpers/utc.js
+++ b/app/helpers/utc.js
@@ -1,0 +1,1 @@
+export { default, utc } from 'ember-moment/helpers/utc';

--- a/tests/dummy/app/templates/partials/format.hbs
+++ b/tests/dummy/app/templates/partials/format.hbs
@@ -41,6 +41,13 @@
 </div>
 
 <div class="example">
+{{moment-format (utc (moment usIndependenceDay)) 'LLLL'}}
+<code>
+  \{{moment-format (utc (moment usIndependenceDay)) 'LLLL'}}
+</code>
+</div>
+
+<div class="example">
 {{moment-format (moment usIndependenceDay) 'MMM DD, YYYY'}}
 <code>
   \{{moment-format (moment usIndependenceDay) 'MMM DD, YYYY'}}

--- a/tests/dummy/app/templates/partials/moment.hbs
+++ b/tests/dummy/app/templates/partials/moment.hbs
@@ -18,3 +18,24 @@
   \{{moment '12-25-1995' 'MM-DD-YYYY'}}
 </code>
 </div>
+
+<div class="example">
+{{utc '12-25-1995 23:45:21' 'MM-DD-YYYY HH:mm:ss'}}
+<code>
+  \{{utc '12-25-1995 23:45:21' 'MM-DD-YYYY HH:mm:ss'}}
+</code>
+</div>
+
+<div class="example">
+{{utc interval=1000}}
+<code>
+  \{{utc interval=1000}}
+</code>
+</div>
+
+<div class="example">
+{{utc (moment now)}}
+<code>
+  \{{utc (moment now)}}
+</code>
+</div>

--- a/tests/unit/helpers/utc-test.js
+++ b/tests/unit/helpers/utc-test.js
@@ -1,0 +1,58 @@
+import moment from 'moment';
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+
+let utc = moment.utc;
+
+moduleForComponent('utc', {
+  integration: true,
+  beforeEach() {
+    this.container.lookup('service:moment').changeLocale('en');
+  },
+  afterEach() {
+    moment.utc = utc;
+    self.moment.utc = utc;
+  }
+});
+
+test('returns the result of moment.utc', function(assert) {
+  assert.expect(1);
+
+  const timeStr = '2001-10-31T13:24:56';
+  const fmtStr = 'YYYY-MM-DDTHH:mm:ss';
+  const momentService = this.container.lookup('service:moment');
+  const current = momentService.utc(timeStr, fmtStr);
+  moment.utc = () => current;
+  this.render(hbs`{{moment-format (utc) 'YYYY-MM-DDTHH:mm:ss'}}`);
+  assert.equal(this.$().text(), timeStr);
+});
+
+test('returns the result of self.moment.utc', function(assert) {
+  assert.expect(1);
+
+  const timeStr = '2001-10-31T13:24:56';
+  const fmtStr = 'YYYY-MM-DDTHH:mm:ss';
+  const momentService = this.container.lookup('service:moment');
+  const current = momentService.utc(timeStr, fmtStr);
+  self.moment.utc = () => current;
+  this.render(hbs`{{moment-format (utc) 'YYYY-MM-DDTHH:mm:ss'}}`);
+  assert.equal(this.$().text(), timeStr);
+});
+
+test('utc of existing moment', function(assert) {
+  assert.expect(2);
+
+  const utcTimeStr = '2001-10-31T13:24:56 +00:00';
+  const estTimeStr = '2001-10-31T08:24:56 -05:00';
+  const fmtStr = 'YYYY-MM-DDTHH:mm:ss Z';
+  const momentService = this.container.lookup('service:moment');
+  const estValue = momentService.moment(estTimeStr, fmtStr);
+  this.set('estValue', estValue);
+  const utcValue = momentService.utc(utcTimeStr, fmtStr);
+  this.set('utcValue', utcValue);
+  this.render(hbs`{{moment-format (utc estValue) 'YYYY-MM-DDTHH:mm:ss Z'}}`);
+  assert.equal(this.$().text(), utcTimeStr);
+
+  this.render(hbs`{{moment-format (utc utcValue) 'YYYY-MM-DDTHH:mm:ss Z'}}`);
+  assert.equal(this.$().text(), utcTimeStr);
+});


### PR DESCRIPTION

Adds support for moment.utc so that you can do things like:

```hbs
{{utc interval=1000}}
{{utc (moment now)}}    {{!-- Mon Feb 12 2018 21:30:20 GMT+0000 --}}
{{moment-format (utc) 'YYYY-MM-DD HH:mm:ss Z'}}    {{!-- 2018-02-12 21:30:20 +00:00 --}}
{{utc '2018-01-01T00:00:00+01:00' 'YYYY-MM-DD HH:mm:ssZ'}}  {{!-- Sun Dec 31 2017 23:00:00 GMT+0000 --}}
```
Also included a utc computed property macro, which I think takes care of Issue #270 .
