### PR TITLE
consistent yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4398,7 +4398,7 @@ moment-timezone@^0.5.0, moment-timezone@^0.5.13:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.13.0, moment@^2.18.1:
+"moment@>= 2.9.0", moment@^2.18.1, moment@^2.19.3:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 


### PR DESCRIPTION
one of the versions of `moment` was wrong in the `yarn.lock`