### PR TITLE
`defineLocale` in moment service

### DIFF
--- a/addon/services/moment.js
+++ b/addon/services/moment.js
@@ -51,6 +51,15 @@ export default Service.extend(Evented, {
     moment.updateLocale(locale, localeOptions);
     this.trigger('localeChanged', locale);
   },
+  
+  defineLocale(locale, localeOptions = {}) {
+    setProperties(this, {
+      locale,
+      localeOptions
+    });
+    moment.defineLocale(locale, localeOptions);
+    this.trigger('localeChanged', locale);
+  },
 
   setTimeZone(timeZone) {
     this.changeTimeZone(timeZone);

--- a/tests/integration/moment-test.js
+++ b/tests/integration/moment-test.js
@@ -103,3 +103,22 @@ test('moment can update service locale (updateLocale)', function(assert) {
   this.service.updateLocale('en', { week: { dow: 0 } });
   assert.equal(moment().weekday(0).format('dddd'), 'Sunday');
 });
+
+test('moment can define service locale (defineLocale)', function(assert) {
+  assert.expect(1);
+  
+  this.setProperties({
+    inputFormat: 'M/D/YY',
+    outputFormat: 'dddd, MMMM D, YYYY',
+    date: '4/19/20'
+  });
+
+  this.service.defineLocale('en-alt', {
+    parentLocale: 'en', 
+    months: ['Jan', 'Feb', 'Mar', 'TEST', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  });
+
+  this.render(hbs`{{moment-format (moment date inputFormat) outputFormat}}`);
+
+  assert.equal(this.$().text(), 'Sunday, TEST 19, 2020');
+});


### PR DESCRIPTION
since moment 2.12.0, it is possible to create locales that inherit from an existing parent locale via [`moment.defineLocale`](https://momentjscom.readthedocs.io/en/latest/moment/07-customization/00-intro/)

adds `defineLocale` to moment service, related test