### PR TITLE
Fix install ember-cli-moment-shim in addon blueprint

### DIFF
--- a/blueprints/ember-moment/index.js
+++ b/blueprints/ember-moment/index.js
@@ -9,6 +9,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addAddonToProject('ember-cli-moment-shim', '^3.4.0');
+    return this.addAddonToProject({ name: 'ember-cli-moment-shim', target: '^3.4.0' });
   }
 };


### PR DESCRIPTION
Hi!

The unsupported signature of the [`addAddonToProject`](https://ember-cli.com/api/classes/Blueprint.html#method_addAddonToProject) method is used, as a result of which the latest version of `ember-cli-moment-shim` installed.

~We have an application running on `ember-cli@2.4.3`, and we cannot update it due to various dependencies.~
~Is it possible to make the same fixes for `ember-moment@7.0.1` and release the new version `7.0.2`?~

I did not notice that versions `7.0.2` and `7.0.3` have already been published.
In any case, it doesn’t matter anymore, the problem is resolved, thanks.
