### PR TITLE
Remove deprecated feature

### DIFF
--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -1,4 +1,3 @@
-import { deprecate } from '@ember/application/deprecations';
 import { get } from '@ember/object';
 
 import computeFn from '../utils/helper-compute';

--- a/addon/helpers/moment-from-now.js
+++ b/addon/helpers/moment-from-now.js
@@ -5,17 +5,10 @@ import computeFn from '../utils/helper-compute';
 import BaseHelper from './-base';
 
 export default BaseHelper.extend({
-  compute: computeFn(function(params, { hideSuffix, hideAffix, locale, timeZone }) {
-    deprecate(
-      'hideSuffix is deprecated in favour of hideAffix',
-      hideSuffix === undefined,  // display if this is false
-      {id: 'ember-moment.addon.helpers.moment-from-now', until: '8.0.0'}
-    );
-
+  compute: computeFn(function(params, { hideAffix, locale, timeZone }) {
     this._super(...arguments);
 
     const moment = get(this, 'moment');
-    const hide = hideSuffix || hideAffix;
-    return this.morphMoment(moment.moment(...params), { locale, timeZone }).fromNow(hide);
+    return this.morphMoment(moment.moment(...params), { locale, timeZone }).fromNow(hideAffix);
   })
 });

--- a/tests/unit/helpers/moment-from-now-test.js
+++ b/tests/unit/helpers/moment-from-now-test.js
@@ -95,6 +95,6 @@ test('can be called with null', function(assert) {
 
 test('localize arabic - issue 239', function(assert) {
   this.set('date', new Date());
-  this.render(hbs`{{moment-from-now date locale='ar' hideSuffix=true}}`);
+  this.render(hbs`{{moment-from-now date locale='ar' hideAffix=true}}`);
   assert.equal(this.$().text(), 'ثانية واحدة');
 });


### PR DESCRIPTION
Since https://github.com/emberjs/ember.js/pull/19133, ember-source requires passing a `since` option to the `deprecate` function. Since this deprecation is targeted for removal in 8.0 anyway, seems like we can just remove it instead of fixing the issue.